### PR TITLE
Add a simple txt file for HC releases

### DIFF
--- a/HC_RELEASE.txt
+++ b/HC_RELEASE.txt
@@ -1,0 +1,2 @@
+Changes with latest release
+- fix SDO movies URL since NOAA retired the old site


### PR DESCRIPTION
The backend serves up a minimalist text message with changes in a version. We'll manually maintain such a file that can be pulled with the latest tag for a given HC release.