### PR TITLE
Don't make the plain zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,6 @@ jobs:
 
           # zip file for HamClock upgrades
           zip -r "dist/ESPHamClock-V$HC_TAG.zip" ESPHamClock -x "dist/*"
-          cp "dist/ESPHamClock-V$HC_TAG.zip" "dist/ESPHamClock.zip" 
           zip -r "dist/hamclock-contrib.zip" hamclock-contrib -x "dist/*"
 
       - name: Create Release and Upload Asset
@@ -62,7 +61,6 @@ jobs:
           # Grabs file from repo tree and uploads with a label
           gh release create $TAG \
             "./docker/manage-hc-docker-$TAG.sh#Manage HamClock Docker Installs" \
-            "dist/ESPHamClock.zip#HamClock Source Zip" \
             "dist/ESPHamClock-V$HC_TAG.zip#HamClock Source Zip with version" \
             "dist/hamclock-contrib.zip#HamClock 3rd party contributions" \
             --title "HamClock Release: $TAG" \


### PR DESCRIPTION
The plain zip when requested will be provided by HC based on the version-named file and checking the agent for indication of beta. We don't need to store an extra file.