### PR TITLE
Need project name to be consistent

### DIFF
--- a/docker/manage-hc-docker.sh
+++ b/docker/manage-hc-docker.sh
@@ -13,7 +13,8 @@ THIS="$(basename "$0")"
 STARTED_FROM="$PWD"
 cd $HERE
 
-DOCKER_PROJECT=${THIS%.*}
+DOCKER_PROJECT="${THIS%.sh}"
+DOCKER_PROJECT="${DOCKER_PROJECT%-$OHB_MANAGER_VERSION}"
 DEFAULT_TAG=$HC_MANAGER_VERSION
 GIT_TAG=$(git describe --exact-match --tags 2>/dev/null)
 GIT_VERSION=$(git rev-parse --short HEAD 2>/dev/null)


### PR DESCRIPTION
The project name can't change with the version or docker compose gets messed up. It requires a step for people to change the downloaded name and that creates issues.