### PR TITLE
Fix issue 24 - 1 sat planning bug

### DIFF
--- a/ESPHamClock/earthsat.cpp
+++ b/ESPHamClock/earthsat.cpp
@@ -2340,7 +2340,7 @@ void drawDXSatMenu (const SCoord &s)
                     break;
                 case _SMI_PLAN1:
                     // restore DX pane and show tool for sat 0 then restore normal map
-                    dxpaneSat = 1;
+                    dxpaneSat = 0;
                     drawSatPass();
                     drawSatTool();
                     initEarthMap();


### PR DESCRIPTION
When only 1 satellite is selected and the user chooses to do satellite planning, HamClock crahes.

It appears to be a copy and paste bug. Sat indexing starts at 0 and for a single satellite, the one satelite is dxpaneSate=0.