### PR TITLE
Fix: SW_ALARMOUT_PIN should be initialised for output

### DIFF
--- a/ESPHamClock/stopwatch.cpp
+++ b/ESPHamClock/stopwatch.cpp
@@ -117,6 +117,13 @@ static bool alarmSwitchIsTrue(void)
     return (!readMCPPoller (SW_ALARMOFF_PIN));
 }
 
+/* init the alarm clock output pin
+ */
+static void initAlarmPin (void)
+{
+    mcp.pinMode (SW_ALARMOUT_PIN, OUTPUT);
+}
+
 /* control the alarm clock output pin
  */
 static void setAlarmPin (bool set)
@@ -2377,6 +2384,7 @@ void initStopwatch()
     startMCPPoller (SW_ALARMOFF_PIN);
 
     setCDLEDState (SWCDS_OFF);
+    initAlarmPin ();
     setAlarmPin (false);
 }
 


### PR DESCRIPTION
the SW_ALARMOUT_PIN alarm output on RPi GPIO pin 6 (header 31) never seems to activate for an alarm. Measuring the pin voltage indicates it is still in default INPUT mode.

Examining stopwatch.cpp, it only uses setAlarmPin to digitalWrite. Pin is never initialised for output. This change fixes that.

Change plucked from original fix at https://github.com/tardate/ESPHamClock/pull/3