### PR TITLE
Add support to change timeout for image files

### DIFF
--- a/ESPHamClock/ArduinoLib/Arduino.cpp
+++ b/ESPHamClock/ArduinoLib/Arduino.cpp
@@ -581,6 +581,8 @@ static void crackArgs (int ac, char *av[])
 						if (ac < 2)
 							usage ("Missing timeout for -T");
 						uint8_t to = atoi(*++av);
+						if (to < 1 || to > 65)
+                            usage ("-T must be [1,65]");
 						ac--;
 						set_timeout_s(to);
 					}

--- a/ESPHamClock/ArduinoLib/Arduino.cpp
+++ b/ESPHamClock/ArduinoLib/Arduino.cpp
@@ -13,7 +13,7 @@
 #include <sys/resource.h>
 
 #include "Arduino.h"
-
+#include "timeout.h"
 // max cpu usage, throttle with -t
 #define DEF_CPU_USAGE 0.8F
 static float max_cpu_usage = DEF_CPU_USAGE;
@@ -30,10 +30,12 @@ const char *diag_files[N_DIAG_FILES] = {
     "diagnostic-log-1.txt",
     "diagnostic-log-2.txt"
 };
-
-
+// helper macro to get value of macro without quotes
+#define STRINGIFY(x) #x
+#define TOSTRING(x)  STRINGIFY(x)
 // how we were made
 char build_variables[64];
+char build_B[128];				  
 
 #if defined(_USE_FB0)
   #if defined(_CLOCK_1600x960)
@@ -80,6 +82,9 @@ static void initBuildVariables(void)
     #if defined(_FB_DEPTH)
         snprintf (build_variables, sizeof(build_variables), "FB_DEPTH=%d ", _FB_DEPTH);
     #endif
+    #if defined(_T)
+        snprintf (build_variables+strlen(build_variables), sizeof(build_variables)-strlen(build_variables), "T=%d ", _T);
+    #endif				   
     #if defined(_WIFI_NEVER)
         strcat(build_variables, "WIFI_NEVER=1 ");
     #endif
@@ -393,6 +398,7 @@ static void usage (const char *errfmt, ...)
                                     LIVEWEB_RO_PORT);
             fprintf (stderr, " -s d : start time as if UTC now is d formatted as YYYY-MM-DDTHH:MM:SS\n");
             fprintf (stderr, " -t p : throttle max cpu to p percent; default is %.0f\n", DEF_CPU_USAGE*100);
+            fprintf (stderr, " -T t : set max timeout for responses from backend\n");			
             fprintf (stderr, " -v   : show version info then exit\n");
             fprintf (stderr, " -w p : set read-write live web server port to p or -1 to disable; default %d\n",
                                     LIVEWEB_RW_PORT);
@@ -427,7 +433,16 @@ static void crackArgs (int ac, char *av[])
         const char *new_appdir = NULL;
         bool cl_set = false;
         int max_lw = 0;
-
+// process build variables before processing command options that override them
+    #if defined(_T)
+		{
+			char *myt = strdup(TOSTRING(_T));
+			uint8_t to = atoi(myt);
+			if (to < 1  || to > 65)	
+				usage ("build error, T=timout, timeout must be [1,65] seconds");
+			set_timeout_s(to);
+		}
+    #endif
         while (--ac && **++av == '-') {
             char *s = *av;
             while (*++s) {
@@ -562,6 +577,14 @@ static void crackArgs (int ac, char *av[])
                         usage ("-t percentage must be [10,100]");
                     ac--;
                     break;
+				case 'T': {
+						if (ac < 2)
+							usage ("Missing timeout for -T");
+						uint8_t to = atoi(*++av);
+						ac--;
+						set_timeout_s(to);
+					}
+					break;
                 case 'v':
                     showVersion();
                     exit(0);

--- a/ESPHamClock/ArduinoLib/ESP8266httpUpdate.cpp
+++ b/ESPHamClock/ArduinoLib/ESP8266httpUpdate.cpp
@@ -264,7 +264,7 @@ t_httpUpdate_return ESPhttpUpdate::update(WiFiClient &client, const char *url)
 	    return (HTTP_UPDATE_FAILED);
 
 	// download url into tmp_dir naming it zip_file
-	if (!runCommand (false, 2, 8, 1, "curl --max-time 30 --retry 2 --silent --show-error --output '%s/%s' '%s'",
+	if (!runCommand (false, 2, 8, 1, "curl --max-time 15 --retry 2 --silent --show-error --output '%s/%s' '%s'",
                                                                 tmp_dir, zip_file, url)) {
             cleanupDir (tmp_dir);
 	    return (HTTP_UPDATE_FAILED);

--- a/ESPHamClock/ArduinoLib/ESP8266httpUpdate.cpp
+++ b/ESPHamClock/ArduinoLib/ESP8266httpUpdate.cpp
@@ -264,7 +264,7 @@ t_httpUpdate_return ESPhttpUpdate::update(WiFiClient &client, const char *url)
 	    return (HTTP_UPDATE_FAILED);
 
 	// download url into tmp_dir naming it zip_file
-	if (!runCommand (false, 2, 8, 1, "curl --max-time 15 --retry 2 --silent --show-error --output '%s/%s' '%s'",
+	if (!runCommand (false, 2, 8, 1, "curl --max-time 30 --retry 2 --silent --show-error --output '%s/%s' '%s'",
                                                                 tmp_dir, zip_file, url)) {
             cleanupDir (tmp_dir);
 	    return (HTTP_UPDATE_FAILED);

--- a/ESPHamClock/ArduinoLib/Makefile
+++ b/ESPHamClock/ArduinoLib/Makefile
@@ -21,7 +21,6 @@ OBJS = \
 	Serial.o \
         SPI.o \
 	Time.o \
-	timeout.o \
 	WiFiClient.o \
 	WiFiServer.o \
 	WiFiUdp.o \

--- a/ESPHamClock/ArduinoLib/Makefile
+++ b/ESPHamClock/ArduinoLib/Makefile
@@ -21,12 +21,14 @@ OBJS = \
 	Serial.o \
         SPI.o \
 	Time.o \
+	timeout.o \
 	WiFiClient.o \
 	WiFiServer.o \
 	WiFiUdp.o \
         Wire.o \
 	i2cdriver.o \
-	passwords.o
+	passwords.o \
+	timeout.o
 
 default:
 	@echo "This Makefile is not intended for stand-alone use -- use only from HamClock's main Makefile"

--- a/ESPHamClock/ArduinoLib/WiFiClient.cpp
+++ b/ESPHamClock/ArduinoLib/WiFiClient.cpp
@@ -13,6 +13,7 @@ WiFiClient::WiFiClient()
 	socket = -1;
 	n_peek = 0;
         next_peek = 0;
+		read_pending_ms = get_timeout_ms();
 }
 
 // constructor handed an open socket to use
@@ -254,7 +255,7 @@ int WiFiClient::available (int pending_ms)
  */
 int WiFiClient::read()
 {
-        if (available (READ_PENDING_MS)) {
+        if (available (read_pending_ms)) {
             uint8_t p = peek[next_peek++];
             if (debugLevel (DEBUG_NET, 3)) {
                 int n_more = n_peek - next_peek;
@@ -268,14 +269,14 @@ int WiFiClient::read()
 	return (-1);
 }
 
-/* wait as long as READ_PENDING_MS to read up to count more bytes into array.
+/* wait as long as read_pending_ms to read up to count more bytes into array.
  * return actual count or 0 when no more.
  */
 int WiFiClient::readArray (uint8_t *array, long count)
 {
         int n_return = 0;
 
-        if (available (READ_PENDING_MS)) {
+        if (available (read_pending_ms)) {
             int n_available = n_peek - next_peek;
             n_return = count > n_available ? n_available : count;
             memcpy (array, &peek[next_peek], n_return);

--- a/ESPHamClock/ArduinoLib/WiFiClient.h
+++ b/ESPHamClock/ArduinoLib/WiFiClient.h
@@ -29,6 +29,7 @@
 
 #include "Arduino.h"
 #include "IPAddress.h"
+#include "timeout.h"
 
 class WiFiClient {
 
@@ -63,7 +64,7 @@ class WiFiClient {
 
     private:
 
-        const int READ_PENDING_MS = 10000;      // max read wait time, ms
+    uint16_t read_pending_ms;               // max read wait time, ms
 	int socket;                             // open if >= 0
   	uint8_t peek[4096*10];                  // read-ahead buffer
   	int n_peek;                             // n useful values in peek[]

--- a/ESPHamClock/ArduinoLib/timeout.cpp
+++ b/ESPHamClock/ArduinoLib/timeout.cpp
@@ -1,0 +1,22 @@
+// timeout.cpp
+#include "timeout.h"
+#include <algorithm>
+
+static uint16_t s_timeout_ms = TIMEOUT_DEFAULT_MS;
+
+uint16_t get_timeout_ms()
+{
+    return s_timeout_ms;
+}
+
+void set_timeout_ms(uint16_t ms)
+{
+    s_timeout_ms = ms;
+}
+
+void set_timeout_s(uint8_t s)
+{
+    s_timeout_ms = static_cast<uint16_t>(
+        std::min(static_cast<uint32_t>(s) * 1000u,
+                 static_cast<uint32_t>(TIMEOUT_MAX_MS)));
+}

--- a/ESPHamClock/ArduinoLib/timeout.h
+++ b/ESPHamClock/ArduinoLib/timeout.h
@@ -1,0 +1,20 @@
+// timeout.h
+#ifndef TIMEOUT_H
+#define TIMEOUT_H
+
+#include <stdint.h>
+
+// Default timeout in milliseconds
+static constexpr uint16_t TIMEOUT_DEFAULT_MS = 10000;
+static constexpr uint16_t TIMEOUT_MAX_MS     = 65535;
+
+// Get the current timeout in milliseconds
+uint16_t get_timeout_ms();
+
+// Set timeout in milliseconds
+void set_timeout_ms(uint16_t ms);
+
+// Set timeout in seconds (converted to ms internally)
+void set_timeout_s(uint8_t s);
+
+#endif // TIMEOUT_H

--- a/ESPHamClock/Makefile
+++ b/ESPHamClock/Makefile
@@ -21,6 +21,10 @@ ifdef FB_DEPTH
     CXXFLAGS += -D_FB_DEPTH=$(FB_DEPTH)
 endif
 
+# add server alias as _T if defined
+ifdef T
+    CXXFLAGS += -D_T=$(T)
+endif
 # handle WiFi configuration
 ifeq ($(WIFI_NEVER),1)
     CXXFLAGS += -D_WIFI_NEVER
@@ -172,7 +176,8 @@ help:
 	@printf "Optional command line variables which may be set before the desired target:\n"
 	@printf "    FB_DEPTH=16 or 32         - Specify a given frame buffer pixel size (default is 32 on all but fb0)\n"
 	@printf "    WIFI_NEVER=1              - Disable WiFi fields in setup (already the default on all but fb0)\n"
-
+	@printf "    T=time                    - Set timout default (seconds) so -b is not required if timout to backend need to be increased\n"
+ 
 
 # supporting libs
 hclibs:


### PR DESCRIPTION
  initBuildVariables support for T=
  crackArgs for -T with hancling of build args T=
  usage updated to reflect -T options
  included timer.h to access shared timer with WiFiClient.h
ArduinoLib/WiFiClient.cpp
  included timer.h to access shared timer value
  made read_pending_ms (from READ_PENDING_S) to get value from timer.h method
  updated to use changeable timeout default
ArduinoLib/WiFiClient.h
  updated to change definition of private attribute for timeout
Makefile
  updated to process T make parameter
ArduinoLib/Makefile
  updated to add in timeout.h and timeout.cpp
ArduinoLib/timeout.h
  provide shared timer
ArduinoLib/timeout.cpp
  provide shared timer
Ardinuolib/ESP8266httpUpdate.cpp
  increased timeout for OTA curl command from 15 to 30 seconds to add headroom for possibly larger zip file
  (discovered timeout when I forgot to remove .o files before build local test zip)