### PR TITLE
Version to use during development

### DIFF
--- a/ESPHamClock/version.cpp
+++ b/ESPHamClock/version.cpp
@@ -1,3 +1,3 @@
 // N.B. if beta be sure to use 2 places: 4.09b01
 
-const char *hc_version = "4.23";
+const char *hc_version = "4.23b99";


### PR DESCRIPTION
The version field needs to conform to d.dd[bdd] where d is a digit. But let's not put 4.23 here yet. If someone pulls main and builds it they get the wrong number. We should have this be some beta version but not collide with real beta tags. b99 seems like a good way to flag this is devel and not a real beta. I hope we don't get to 99 betas.