### PR TITLE
Where version is pokes, allow beta to be replaced

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           echo "TAG=$TAG" > VERSION.txt
 
           # update version in HC source
-          sed -i 's/\(hc_version = "\)[0-9.]\+/\1'$HC_TAG'/' ESPHamClock/version.cpp
+          sed -i 's/\(hc_version = "\)[^"]\+\(".*\)/\1'$HC_TAG'\2/' ESPHamClock/version.cpp
 
           # create the tars and zips
           mkdir dist

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -135,7 +135,7 @@ poke_version_cpp() {
         HC_TAG=${GIT_VERSION%.*}
         HC_TAG=${HC_TAG#v}
         HC_TAG=${HC_TAG#V}
-        sed -i 's/\(hc_version = "\)[0-9.]\+/\1'$HC_TAG'/' ESPHamClock/version.cpp
+        sed -i 's/\(hc_version = "\)[^"]\+\(".*\)/\1'$HC_TAG'\2/' ESPHamClock/version.cpp
     fi
 }
 


### PR DESCRIPTION
The sed was not picking up the whole beta version to replace with the expected tag.