### PR TITLE
Getting ready for move to org

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Specific documentation included here:
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at
-<https://github.com/komacke/hamclock/issues>
+<https://github.com/openhamclock/hamclock/issues>

--- a/debian/csi
+++ b/debian/csi
@@ -8,7 +8,7 @@
 # You may not misrepresent the original authorship of this work.
 #
 
-GITHUB_RAW_URL="https://raw.githubusercontent.com/komacke/hamclock/main/debian/csi"
+GITHUB_RAW_URL="https://raw.githubusercontent.com/openhamclock/hamclock/main/debian/csi"
 SELF_UPDATE_FLAG="CSI_SELF_UPDATED"
 
 HOSTS_FILE="/etc/hosts"

--- a/debian/fix-hosts
+++ b/debian/fix-hosts
@@ -8,7 +8,7 @@
 # You may not misrepresent the original authorship of this work.
 #
 
-GITHUB_RAW_URL="https://raw.githubusercontent.com/komacke/hamclock/main/debian/fix-hosts"
+GITHUB_RAW_URL="https://raw.githubusercontent.com/openhamclock/hamclock/main/debian/fix-hosts"
 SELF_UPDATE_FLAG="FIX_HOSTS_SELF_UPDATED"
 
 OS_RELEASE="/etc/os-release"

--- a/debian/hcdc
+++ b/debian/hcdc
@@ -8,7 +8,7 @@
 # You may not misrepresent the original authorship of this work.
 #
 
-GITHUB_RAW_URL="https://raw.githubusercontent.com/komacke/hamclock/main/debian/hcdc"
+GITHUB_RAW_URL="https://raw.githubusercontent.com/openhamclock/hamclock/main/debian/hcdc"
 SELF_UPDATE_FLAG="HCDC_SELF_UPDATED"
 
 HOSTS_FILE="/etc/hosts"

--- a/debian/install-hc-rpi
+++ b/debian/install-hc-rpi
@@ -90,7 +90,7 @@ get_hamclock_source_url() {
     fi
 
     # GitHub API endpoint for releases
-    local api_url="https://api.github.com/repos/komacke/hamclock/releases"
+    local api_url="https://api.github.com/repos/openhamclock/hamclock/releases"
 
     # Define the target filename we are looking for
     local target_asset="ESPHamClock-V${substring}.zip"

--- a/debian/ohb
+++ b/debian/ohb
@@ -8,7 +8,7 @@
 # You may not misrepresent the original authorship of this work.
 #
 
-GITHUB_RAW_URL="https://raw.githubusercontent.com/komacke/hamclock/main/debian/ohb"
+GITHUB_RAW_URL="https://raw.githubusercontent.com/openhamclock/hamclock/main/debian/ohb"
 SELF_UPDATE_FLAG="OHB_SELF_UPDATED"
 
 HOSTS_FILE="/etc/hosts"

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,7 +7,7 @@ This is a dockerized deployment of the web version of HamClock.
 Grab the ```manage-hc-docker.sh``` file from the releases page. That file has a version in the name. I recommend renaming it, or do it all at once with a curl:
 
 ```sh
-curl -sLo manage-hc-docker.sh 'https://github.com/komacke/hamclock/releases/download/v4.22.0/manage-hc-docker-v4.22.0.sh'
+curl -sLo manage-hc-docker.sh 'https://github.com/openhamclock/hamclock/releases/download/v4.22.0/manage-hc-docker-v4.22.0.sh'
 chmod +x manage-hc-docker.sh
 ```
 
@@ -18,4 +18,4 @@ NOTE: you can select from the 4 possible sizes with the -s option: ```800x480 16
 
 ### Preconfigure it on a first run
 
-The first time you run it, you can preconfigure some of your personal settings. Look for the [config.env.example](https://github.com/komacke/hamclock/blob/main/docker/config.env.example) file. Name it config.env and put it in the same folder with your manage-hc-docker.sh. Edit it as you like and it will pre-configure your hamclock. If you don't use the config.env, you'll get the usual setup screen for a fresh install.
+The first time you run it, you can preconfigure some of your personal settings. Look for the [config.env.example](https://github.com/openhamclock/hamclock/blob/main/docker/config.env.example) file. Name it config.env and put it in the same folder with your manage-hc-docker.sh. Edit it as you like and it will pre-configure your hamclock. If you don't use the config.env, you'll get the usual setup screen for a fresh install.

--- a/docker/manage-hc-docker.sh
+++ b/docker/manage-hc-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 HC_MANAGER_VERSION=latest
-GITHUB_REPO="komacke/hamclock"
+GITHUB_REPO="openhamclock/hamclock"
 
 IMAGE_BASE=komacke/hamclock
 


### PR DESCRIPTION
These old links will redirect automatically after the move but we want to get the new links in place soon after.