### PR TITLE
Prep for developing 4.24

### DIFF
--- a/ESPHamClock/version.cpp
+++ b/ESPHamClock/version.cpp
@@ -1,3 +1,3 @@
 // N.B. if beta be sure to use 2 places: 4.09b01
 
-const char *hc_version = "4.23";
+const char *hc_version = "4.24b99";

--- a/HC_RELEASE-beta.txt
+++ b/HC_RELEASE-beta.txt
@@ -1,2 +1,2 @@
 Changes with latest release:
-- no beta at this time
+- first beta baseline is 4.23


### PR DESCRIPTION
With 4.23 tagged set up main to be development for 4.24. Establish the default version and baseline the release notes