### PR TITLE
Make the default exactly the same

### DIFF
--- a/ESPHamClock/wifi.cpp
+++ b/ESPHamClock/wifi.cpp
@@ -3,12 +3,12 @@
 
 #include "HamClock.h"
 
-
+#define DEFAULT_HOST "clearskyinstitute.com"
 // host name and port of backend server
-const char *backend_host = "clearskyinstitute.com";
+const char *backend_host = DEFAULT_HOST;
 int backend_port = 80;
 // host name of software server
-const char *software_host = "clearskyinstitute.com";
+const char *software_host = DEFAULT_HOST;
 // IP where server thinks we came from
 char remote_addr[16];                           // INET_ADDRSTRLEN
 


### PR DESCRIPTION
Make it easy to change the default with a define and ensure software_host and backend_host default to the same.

This is not to be confused with the B= and S= compile-time options which are intended to override the defaults.