### PR TITLE
ESPHamClock has an infinite polling loop() - introduce delay of 10ms when fast polling is not needed

### DIFF
--- a/ESPHamClock/ESPHamClock.cpp
+++ b/ESPHamClock/ESPHamClock.cpp
@@ -602,7 +602,6 @@ void setup()
     rss_bnr_b.w = map_b.w;
     rss_bnr_b.h = 68;
     NVReadUInt8 (NV_RSS_ON, &rss_on);
-    initLightning();
     if (!NVReadUInt8 (NV_RSS_INTERVAL, &rss_interval) || rss_interval < RSS_MIN_INT) {
         rss_interval = RSS_DEF_INT;
         NVWriteUInt8 (NV_RSS_INTERVAL, rss_interval);
@@ -653,6 +652,17 @@ void setup()
     initScreen();
 }
 
+// mouseoverMap
+// Return true if the mouse is over the map area that requires rapid polling of cursor coordinates
+
+static bool mouseOverMap()
+{
+      SCoord s;
+      if (!tft.getMouse (&s.x, &s.y))
+              return (false);
+      return (overMap (s));
+}
+
 // called repeatedly forever
 void loop()
 {
@@ -695,6 +705,10 @@ void loop()
 
         // check for touch events
         checkTouch();
+
+		if (!mouseOverMap()) {
+			delay(10);
+		}
     }
 }
 
@@ -1702,7 +1716,6 @@ void drawAllSymbols()
     drawDEMarker(false);
     drawDXMarker(false);
     drawFarthestPSKSpots();
-    drawLightningOnMap();
     drawSanta ();
 
     updateClocks(false);

--- a/ESPHamClock/ESPHamClock.cpp
+++ b/ESPHamClock/ESPHamClock.cpp
@@ -602,6 +602,7 @@ void setup()
     rss_bnr_b.w = map_b.w;
     rss_bnr_b.h = 68;
     NVReadUInt8 (NV_RSS_ON, &rss_on);
+    initLightning();
     if (!NVReadUInt8 (NV_RSS_INTERVAL, &rss_interval) || rss_interval < RSS_MIN_INT) {
         rss_interval = RSS_DEF_INT;
         NVWriteUInt8 (NV_RSS_INTERVAL, rss_interval);
@@ -1716,6 +1717,7 @@ void drawAllSymbols()
     drawDEMarker(false);
     drawDXMarker(false);
     drawFarthestPSKSpots();
+    drawLightningOnMap();
     drawSanta ();
 
     updateClocks(false);


### PR DESCRIPTION
save cpu when cursor is not over map by doing a delay of 10ms each loop() interation - cursor hove rover in map can't take any delay

Fast polling is only needed when the cursor is over the map so that lat/long in popup and city information (if on) is displayed quickly.  CPU on Pi 3B drops from 60+ down to ~10 when cursor is moved off the map window pane.

See snapshots from hamclock running in WSL
from 40+
<img width="1521" height="467" alt="image" src="https://github.com/user-attachments/assets/b2ea6e68-42c4-43eb-8aa4-f7988e0fb97a" />

down to under 10

<img width="1550" height="411" alt="image" src="https://github.com/user-attachments/assets/cd4e4be0-5150-44ba-a153-e4f95e12219a" />

73 de Dave KR8X




