### PR TITLE
Migrate back to main

### DIFF
--- a/debian/csi
+++ b/debian/csi
@@ -8,10 +8,7 @@
 # You may not misrepresent the original authorship of this work.
 #
 
-#STABLE_TAG=v4.23.0
-#RLS_PATH=refs/tags/$STABLE_TAG
-RLS_PATH=main
-GITHUB_RAW_URL="https://raw.githubusercontent.com/openhamclock/hamclock/$RLS_PATH/debian/csi"
+GITHUB_RAW_URL="https://raw.githubusercontent.com/openhamclock/hamclock/refs/heads/main/debian/csi"
 SELF_UPDATE_FLAG="CSI_SELF_UPDATED"
 
 HOSTS_FILE="/etc/hosts"
@@ -31,7 +28,6 @@ HAMCLOCK_DIR="$USER_HOME/.hamclock"
 
 DESKTOP_FILE="$USER_HOME/Desktop/hamclock.desktop"
 AUTOSTART_FILE="$USER_HOME/.config/autostart/hamclock.desktop"
-XFCE_PANEL_DIR="$USER_HOME/.config/xfce4/panel"
 RUNNER_FILE="/usr/local/bin/hamclock-runner"
 XRANDR_WRAPPER_FILE="/usr/local/bin/hamclock-xrandr-wrapper"
 SERVICE_FILE="/etc/systemd/system/hamclock.service"
@@ -237,61 +233,6 @@ patch_file() {
     return 0
 }
 
-patch_xfce_panel_launchers() {
-    local panel_file
-    local tmpfile
-
-    [ -d "$XFCE_PANEL_DIR" ] || return 0
-
-    while IFS= read -r panel_file; do
-        grep -Eq '^[[:space:]]*Exec=(/usr/local/bin/)?hamclock(-4k)?([[:space:]]|$)' "$panel_file" || continue
-        grep -Eq '^[[:space:]]*Exec=.*(hamclock-xrandr-wrapper|hamclock-runner)([[:space:]]|$)' "$panel_file" && continue
-
-        tmpfile=$(mktemp) || {
-            echo "Error: could not create temporary file."
-            exit 1
-        }
-
-        if ! awk '
-            {
-                line = $0
-
-                if (line ~ /^[[:space:]]*Exec=/) {
-                    gsub(/[[:space:]]+-b[[:space:]]+[^[:space:]'\''";)]+/, "", line)
-                }
-
-                print line
-            }
-        ' "$panel_file" > "$tmpfile"; then
-            rm -f "$tmpfile"
-            echo "Error: failed to process $panel_file."
-            exit 1
-        fi
-
-        if [ ! -s "$tmpfile" ]; then
-            rm -f "$tmpfile"
-            echo "Error: generated empty output for $panel_file, refusing to overwrite."
-            exit 1
-        fi
-
-        if cmp -s "$panel_file" "$tmpfile"; then
-            rm -f "$tmpfile"
-            continue
-        fi
-
-        if ! cat "$tmpfile" > "$panel_file"; then
-            rm -f "$tmpfile"
-            echo "Error: failed to update $panel_file."
-            exit 1
-        fi
-
-        rm -f "$tmpfile"
-        preserve_user_ownership "$panel_file"
-        changed_files+=("$panel_file")
-        anything_changed=1
-    done < <(find "$XFCE_PANEL_DIR" -type f -name '*.desktop')
-}
-
 # Count matching non-comment lines in /etc/hosts
 match_count=$(grep -E "^[[:space:]]*[^#].*[[:space:]]$DOMAIN([[:space:]]|$)" "$HOSTS_FILE" | wc -l)
 
@@ -330,7 +271,6 @@ patch_file "$DESKTOP_FILE" "desktop"
 patch_file "$AUTOSTART_FILE" "desktop"
 patch_file "$RUNNER_FILE" "runner"
 patch_file "$XRANDR_WRAPPER_FILE" "xrandr_wrapper"
-patch_xfce_panel_launchers
 
 if patch_file "$SERVICE_FILE" "service"; then
     service_changed=1

--- a/debian/fix-hosts
+++ b/debian/fix-hosts
@@ -8,10 +8,7 @@
 # You may not misrepresent the original authorship of this work.
 #
 
-#STABLE_TAG=v4.23.0
-#RLS_PATH=refs/tags/$STABLE_TAG
-RLS_PATH=main
-GITHUB_RAW_URL="https://raw.githubusercontent.com/openhamclock/hamclock/$RLS_PATH/debian/fix-hosts"
+GITHUB_RAW_URL="https://raw.githubusercontent.com/openhamclock/hamclock/refs/heads/main/debian/fix-hosts"
 SELF_UPDATE_FLAG="FIX_HOSTS_SELF_UPDATED"
 
 OS_RELEASE="/etc/os-release"

--- a/debian/hcdc
+++ b/debian/hcdc
@@ -8,10 +8,7 @@
 # You may not misrepresent the original authorship of this work.
 #
 
-#STABLE_TAG=v4.23.0
-#RLS_PATH=refs/tags/$STABLE_TAG
-RLS_PATH=main
-GITHUB_RAW_URL="https://raw.githubusercontent.com/openhamclock/hamclock/$RLS_PATH/debian/hcdc"
+GITHUB_RAW_URL="https://raw.githubusercontent.com/openhamclock/hamclock/refs/heads/main/debian/hcdc"
 SELF_UPDATE_FLAG="HCDC_SELF_UPDATED"
 
 HOSTS_FILE="/etc/hosts"
@@ -31,6 +28,8 @@ fi
 BACKEND_PATTERN="[^[:space:]'\";)]+" 
 ENTRY="$HOSTS_IP $DOMAIN"
 DESKTOP_EXEC_LINE="Exec=sh -c 'until [ -n \"\$DISPLAY\" ] || [ -n \"\$WAYLAND_DISPLAY\" ]; do sleep 1; done; sleep 5; exec /usr/local/bin/hamclock -b $BACKEND_TARGET'"
+WRAPPER_WAIT_LINE_1='until [ -n "$DISPLAY" ] || [ -n "$WAYLAND_DISPLAY" ]; do sleep 1; done'
+WRAPPER_WAIT_LINE_2='sleep 5'
 
 # Work out which user's home to use when run via sudo
 if [ -n "$SUDO_USER" ] && [ "$SUDO_USER" != "root" ]; then
@@ -43,7 +42,6 @@ HAMCLOCK_DIR="$USER_HOME/.hamclock"
 
 DESKTOP_FILE="$USER_HOME/Desktop/hamclock.desktop"
 AUTOSTART_FILE="$USER_HOME/.config/autostart/hamclock.desktop"
-XFCE_PANEL_DIR="$USER_HOME/.config/xfce4/panel"
 RUNNER_FILE="/usr/local/bin/hamclock-runner"
 XRANDR_WRAPPER_FILE="/usr/local/bin/hamclock-xrandr-wrapper"
 SERVICE_FILE="/etc/systemd/system/hamclock.service"
@@ -131,18 +129,6 @@ self_update() {
 
 self_update "$@"
 
-echo
-
-if [ -f "$XRANDR_WRAPPER_FILE" ]; then
-    echo "Device detected as original Quadra"
-elif [ -f "$RUNNER_FILE" ]; then
-    echo "Device detected as Quadra 4K"
-else
-    echo "Device is not a Quadra"
-fi
-
-echo
-
 # Safety check
 if [ ! -f "$HOSTS_FILE" ]; then
     echo "Error: $HOSTS_FILE not found."
@@ -165,6 +151,7 @@ patch_file() {
     local file="$1"
     local mode="$2"
     local tmpfile
+    local tmpfile2
     local cleanfile
     local user
 
@@ -193,10 +180,36 @@ $DESKTOP_EXEC_LINE
             }" "$file" > "$tmpfile"
             ;;
         xrandr_wrapper)
+            tmpfile2=$(mktemp) || {
+                rm -f "$tmpfile"
+                echo "Error: could not create temporary file."
+                exit 1
+            }
+
+            if grep -Eq '\$DISPLAY|\$WAYLAND_DISPLAY' "$file"; then
+                cat "$file" > "$tmpfile2"
+            else
+                awk -v wait1="$WRAPPER_WAIT_LINE_1" -v wait2="$WRAPPER_WAIT_LINE_2" '
+                    NR == 1 && /^#!/ {
+                        print
+                        print wait1
+                        print wait2
+                        next
+                    }
+                    NR == 1 {
+                        print wait1
+                        print wait2
+                    }
+                    { print }
+                ' "$file" > "$tmpfile2"
+            fi
+
             sed -E "/^[[:space:]]*exec=[[:space:]]*\\\$[[:space:]]*\\(/ {
                 s/[[:space:]]+-b[[:space:]]+$BACKEND_PATTERN//g
                 s#(^|[^[:alnum:]_/-])(/usr/local/bin/)?(hamclock|hamclock-4k)([[:space:]'\";)]|$)#\1\2\3 -b $BACKEND_TARGET\4#
-            }" "$file" > "$tmpfile"
+            }" "$tmpfile2" > "$tmpfile"
+
+            rm -f "$tmpfile2"
             ;;
         service)
             sed -E "/^[[:space:]]*ExecStart=/ {
@@ -260,62 +273,6 @@ $DESKTOP_EXEC_LINE
     return 0
 }
 
-patch_xfce_panel_launchers() {
-    local panel_file
-    local tmpfile
-
-    [ -d "$XFCE_PANEL_DIR" ] || return 0
-
-    while IFS= read -r panel_file; do
-        grep -Eq '^[[:space:]]*Exec=(/usr/local/bin/)?hamclock(-4k)?([[:space:]]|$)' "$panel_file" || continue
-        grep -Eq '^[[:space:]]*Exec=.*(hamclock-xrandr-wrapper|hamclock-runner)([[:space:]]|$)' "$panel_file" && continue
-
-        tmpfile=$(mktemp) || {
-            echo "Error: could not create temporary file."
-            exit 1
-        }
-
-        if ! awk -v target="$BACKEND_TARGET" '
-            {
-                line = $0
-
-                if (line ~ /^[[:space:]]*Exec=/) {
-                    gsub(/[[:space:]]+-b[[:space:]]+[^[:space:]'\''";)]+/, "", line)
-                    sub(/(\/usr\/local\/bin\/)?hamclock(-4k)?/, "& -b " target, line)
-                }
-
-                print line
-            }
-        ' "$panel_file" > "$tmpfile"; then
-            rm -f "$tmpfile"
-            echo "Error: failed to process $panel_file."
-            exit 1
-        fi
-
-        if [ ! -s "$tmpfile" ]; then
-            rm -f "$tmpfile"
-            echo "Error: generated empty output for $panel_file, refusing to overwrite."
-            exit 1
-        fi
-
-        if cmp -s "$panel_file" "$tmpfile"; then
-            rm -f "$tmpfile"
-            continue
-        fi
-
-        if ! cat "$tmpfile" > "$panel_file"; then
-            rm -f "$tmpfile"
-            echo "Error: failed to update $panel_file."
-            exit 1
-        fi
-
-        rm -f "$tmpfile"
-        preserve_user_ownership "$panel_file"
-        changed_files+=("$panel_file")
-        anything_changed=1
-    done < <(find "$XFCE_PANEL_DIR" -type f -name '*.desktop')
-}
-
 # Check current /etc/hosts state
 match_count=$(grep -E "^[[:space:]]*[^#].*[[:space:]]$DOMAIN([[:space:]]|$)" "$HOSTS_FILE" | wc -l)
 
@@ -357,7 +314,6 @@ patch_file "$DESKTOP_FILE" "desktop"
 patch_file "$AUTOSTART_FILE" "desktop"
 patch_file "$RUNNER_FILE" "runner"
 patch_file "$XRANDR_WRAPPER_FILE" "xrandr_wrapper"
-patch_xfce_panel_launchers
 
 if patch_file "$SERVICE_FILE" "service"; then
     service_changed=1
@@ -427,10 +383,6 @@ done
 
 if [ "$service_changed" -eq 1 ]; then
     echo "Reloaded systemd and restarted hamclock.service."
-fi
-
-if [ "${#changed_files[@]}" -eq 0 ]; then
-    echo "There were no files found to modify with -b"
 fi
 
 if [ "$anything_changed" -eq 0 ]; then

--- a/debian/ohb
+++ b/debian/ohb
@@ -8,10 +8,7 @@
 # You may not misrepresent the original authorship of this work.
 #
 
-#STABLE_TAG=v4.23.0
-#RLS_PATH=refs/tags/$STABLE_TAG
-RLS_PATH=main
-GITHUB_RAW_URL="https://raw.githubusercontent.com/openhamclock/hamclock/$RLS_PATH/debian/ohb"
+GITHUB_RAW_URL="https://raw.githubusercontent.com/openhamclock/hamclock/refs/heads/main/debian/ohb"
 SELF_UPDATE_FLAG="OHB_SELF_UPDATED"
 
 HOSTS_FILE="/etc/hosts"
@@ -31,6 +28,8 @@ fi
 BACKEND_PATTERN="[^[:space:]'\";)]+" 
 ENTRY="$HOSTS_IP $DOMAIN"
 DESKTOP_EXEC_LINE="Exec=sh -c 'until [ -n \"\$DISPLAY\" ] || [ -n \"\$WAYLAND_DISPLAY\" ]; do sleep 1; done; sleep 5; exec /usr/local/bin/hamclock -b $BACKEND_TARGET'"
+WRAPPER_WAIT_LINE_1='until [ -n "$DISPLAY" ] || [ -n "$WAYLAND_DISPLAY" ]; do sleep 1; done'
+WRAPPER_WAIT_LINE_2='sleep 5'
 
 # Work out which user's home to use when run via sudo
 if [ -n "$SUDO_USER" ] && [ "$SUDO_USER" != "root" ]; then
@@ -43,7 +42,6 @@ HAMCLOCK_DIR="$USER_HOME/.hamclock"
 
 DESKTOP_FILE="$USER_HOME/Desktop/hamclock.desktop"
 AUTOSTART_FILE="$USER_HOME/.config/autostart/hamclock.desktop"
-XFCE_PANEL_DIR="$USER_HOME/.config/xfce4/panel"
 RUNNER_FILE="/usr/local/bin/hamclock-runner"
 XRANDR_WRAPPER_FILE="/usr/local/bin/hamclock-xrandr-wrapper"
 SERVICE_FILE="/etc/systemd/system/hamclock.service"
@@ -131,18 +129,6 @@ self_update() {
 
 self_update "$@"
 
-echo
-
-if [ -f "$XRANDR_WRAPPER_FILE" ]; then
-    echo "Device detected as original Quadra"
-elif [ -f "$RUNNER_FILE" ]; then
-    echo "Device detected as Quadra 4K"
-else
-    echo "Device is not a Quadra"
-fi
-
-echo
-
 # Safety check
 if [ ! -f "$HOSTS_FILE" ]; then
     echo "Error: $HOSTS_FILE not found."
@@ -165,6 +151,7 @@ patch_file() {
     local file="$1"
     local mode="$2"
     local tmpfile
+    local tmpfile2
     local cleanfile
     local user
 
@@ -193,10 +180,36 @@ $DESKTOP_EXEC_LINE
             }" "$file" > "$tmpfile"
             ;;
         xrandr_wrapper)
+            tmpfile2=$(mktemp) || {
+                rm -f "$tmpfile"
+                echo "Error: could not create temporary file."
+                exit 1
+            }
+
+            if grep -Eq '\$DISPLAY|\$WAYLAND_DISPLAY' "$file"; then
+                cat "$file" > "$tmpfile2"
+            else
+                awk -v wait1="$WRAPPER_WAIT_LINE_1" -v wait2="$WRAPPER_WAIT_LINE_2" '
+                    NR == 1 && /^#!/ {
+                        print
+                        print wait1
+                        print wait2
+                        next
+                    }
+                    NR == 1 {
+                        print wait1
+                        print wait2
+                    }
+                    { print }
+                ' "$file" > "$tmpfile2"
+            fi
+
             sed -E "/^[[:space:]]*exec=[[:space:]]*\\\$[[:space:]]*\\(/ {
                 s/[[:space:]]+-b[[:space:]]+$BACKEND_PATTERN//g
                 s#(^|[^[:alnum:]_/-])(/usr/local/bin/)?(hamclock|hamclock-4k)([[:space:]'\";)]|$)#\1\2\3 -b $BACKEND_TARGET\4#
-            }" "$file" > "$tmpfile"
+            }" "$tmpfile2" > "$tmpfile"
+
+            rm -f "$tmpfile2"
             ;;
         service)
             sed -E "/^[[:space:]]*ExecStart=/ {
@@ -260,62 +273,6 @@ $DESKTOP_EXEC_LINE
     return 0
 }
 
-patch_xfce_panel_launchers() {
-    local panel_file
-    local tmpfile
-
-    [ -d "$XFCE_PANEL_DIR" ] || return 0
-
-    while IFS= read -r panel_file; do
-        grep -Eq '^[[:space:]]*Exec=(/usr/local/bin/)?hamclock(-4k)?([[:space:]]|$)' "$panel_file" || continue
-        grep -Eq '^[[:space:]]*Exec=.*(hamclock-xrandr-wrapper|hamclock-runner)([[:space:]]|$)' "$panel_file" && continue
-
-        tmpfile=$(mktemp) || {
-            echo "Error: could not create temporary file."
-            exit 1
-        }
-
-        if ! awk -v target="$BACKEND_TARGET" '
-            {
-                line = $0
-
-                if (line ~ /^[[:space:]]*Exec=/) {
-                    gsub(/[[:space:]]+-b[[:space:]]+[^[:space:]'\''";)]+/, "", line)
-                    sub(/(\/usr\/local\/bin\/)?hamclock(-4k)?/, "& -b " target, line)
-                }
-
-                print line
-            }
-        ' "$panel_file" > "$tmpfile"; then
-            rm -f "$tmpfile"
-            echo "Error: failed to process $panel_file."
-            exit 1
-        fi
-
-        if [ ! -s "$tmpfile" ]; then
-            rm -f "$tmpfile"
-            echo "Error: generated empty output for $panel_file, refusing to overwrite."
-            exit 1
-        fi
-
-        if cmp -s "$panel_file" "$tmpfile"; then
-            rm -f "$tmpfile"
-            continue
-        fi
-
-        if ! cat "$tmpfile" > "$panel_file"; then
-            rm -f "$tmpfile"
-            echo "Error: failed to update $panel_file."
-            exit 1
-        fi
-
-        rm -f "$tmpfile"
-        preserve_user_ownership "$panel_file"
-        changed_files+=("$panel_file")
-        anything_changed=1
-    done < <(find "$XFCE_PANEL_DIR" -type f -name '*.desktop')
-}
-
 # Check current /etc/hosts state
 match_count=$(grep -E "^[[:space:]]*[^#].*[[:space:]]$DOMAIN([[:space:]]|$)" "$HOSTS_FILE" | wc -l)
 
@@ -357,7 +314,6 @@ patch_file "$DESKTOP_FILE" "desktop"
 patch_file "$AUTOSTART_FILE" "desktop"
 patch_file "$RUNNER_FILE" "runner"
 patch_file "$XRANDR_WRAPPER_FILE" "xrandr_wrapper"
-patch_xfce_panel_launchers
 
 if patch_file "$SERVICE_FILE" "service"; then
     service_changed=1
@@ -427,10 +383,6 @@ done
 
 if [ "$service_changed" -eq 1 ]; then
     echo "Reloaded systemd and restarted hamclock.service."
-fi
-
-if [ "${#changed_files[@]}" -eq 0 ]; then
-    echo "There were no files found to modify with -b"
 fi
 
 if [ "$anything_changed" -eq 0 ]; then

--- a/debian/what
+++ b/debian/what
@@ -8,10 +8,7 @@
 # You may not misrepresent the original authorship of this work.
 #
 
-#STABLE_TAG=v4.23.0
-#RLS_PATH=refs/tags/$STABLE_TAG
-RLS_PATH=main
-GITHUB_RAW_URL="https://raw.githubusercontent.com/openhamclock/hamclock/$RLS_PATH/debian/what"
+GITHUB_RAW_URL="https://raw.githubusercontent.com/openhamclock/hamclock/refs/heads/main/debian/what"
 SELF_UPDATE_FLAG="WHAT_SELF_UPDATED"
 
 HAMCLOCK_BIN="/usr/local/bin/hamclock"


### PR DESCRIPTION
The debian scripts are pointing to main again. When updates come out we typically want these available immediately rather than waiting on a release. Although at release time we do get an asset.