### PR TITLE
Fix hot-path redraw churn and make idle map refresh lazy

### DIFF
--- a/ESPHamClock/ArduinoLib/Arduino.cpp
+++ b/ESPHamClock/ArduinoLib/Arduino.cpp
@@ -18,6 +18,7 @@
 #define DEF_CPU_USAGE 0.8F
 static float max_cpu_usage = DEF_CPU_USAGE;
 uint16_t lazy_redraw_s = 30;    // idle map redraw interval, seconds; 0 keeps the original eager sweep
+#define MAX_LAZY_REDRAW_S 600
 // even at 100% throttle, don't busy-spin the host when loop() has nothing to do
 #define DEF_MIN_IDLE_LOOP_US 1000
 
@@ -397,8 +398,9 @@ static void usage (const char *errfmt, ...)
             fprintf (stderr, " -i i : init DE using geolocation with IP i; requires -k\n");
             fprintf (stderr, " -k   : start in normal mode, ie, don't offer Setup or wait for Skips\n");
             fprintf (stderr, " -l l : set Mercator or Robinson center longitude to l degrees, +E; requires -k\n");
-            fprintf (stderr, " -L s : set idle map redraw interval to s seconds; 0 keeps continuous redraw; default %u\n",
-                                    lazy_redraw_s);
+            fprintf (stderr,
+                            " -L s : set idle map redraw interval to s seconds [0,%u]; 0 keeps continuous redraw; default %u\n",
+                            MAX_LAZY_REDRAW_S, lazy_redraw_s);
             fprintf (stderr, " -m   : enable demo mode\n");
             fprintf (stderr, " -n t : set live web idle timeout to t minutes; default forever\n");
             fprintf (stderr, " -o   : write diagnostic log to stdout instead of in %s\n",
@@ -576,8 +578,13 @@ static void crackArgs (int ac, char *av[])
                         if (ac < 2)
                             usage ("missing seconds for -L");
                         int redraw_s = atoi(*++av);
-                        if (redraw_s < 0 || redraw_s > 24*3600)
-                            usage ("-L seconds must be [0,86400]");
+                        if (redraw_s < 0)
+                            usage ("-L seconds must be >= 0");
+                        if (redraw_s > MAX_LAZY_REDRAW_S) {
+                            fprintf (stderr, "Warning: capping -L from %d to %u seconds\n",
+                                                    redraw_s, MAX_LAZY_REDRAW_S);
+                            redraw_s = MAX_LAZY_REDRAW_S;
+                        }
                         lazy_redraw_s = redraw_s;
                         ac--;
                     }

--- a/ESPHamClock/ArduinoLib/Arduino.cpp
+++ b/ESPHamClock/ArduinoLib/Arduino.cpp
@@ -17,6 +17,7 @@
 // max cpu usage, throttle with -t
 #define DEF_CPU_USAGE 0.8F
 static float max_cpu_usage = DEF_CPU_USAGE;
+uint16_t lazy_redraw_s = 30;    // idle map redraw interval, seconds; 0 keeps the original eager sweep
 // even at 100% throttle, don't busy-spin the host when loop() has nothing to do
 #define DEF_MIN_IDLE_LOOP_US 1000
 
@@ -396,6 +397,8 @@ static void usage (const char *errfmt, ...)
             fprintf (stderr, " -i i : init DE using geolocation with IP i; requires -k\n");
             fprintf (stderr, " -k   : start in normal mode, ie, don't offer Setup or wait for Skips\n");
             fprintf (stderr, " -l l : set Mercator or Robinson center longitude to l degrees, +E; requires -k\n");
+            fprintf (stderr, " -L s : set idle map redraw interval to s seconds; 0 keeps continuous redraw; default %u\n",
+                                    lazy_redraw_s);
             fprintf (stderr, " -m   : enable demo mode\n");
             fprintf (stderr, " -n t : set live web idle timeout to t minutes; default forever\n");
             fprintf (stderr, " -o   : write diagnostic log to stdout instead of in %s\n",
@@ -568,6 +571,16 @@ static void crackArgs (int ac, char *av[])
                     setCenterLng(atoi(*++av));
                     cl_set = true;
                     ac--;
+                    break;
+                case 'L': {
+                        if (ac < 2)
+                            usage ("missing seconds for -L");
+                        int redraw_s = atoi(*++av);
+                        if (redraw_s < 0 || redraw_s > 24*3600)
+                            usage ("-L seconds must be [0,86400]");
+                        lazy_redraw_s = redraw_s;
+                        ac--;
+                    }
                     break;
                 case 'm':
                     setDemoMode(true);

--- a/ESPHamClock/ArduinoLib/Arduino.cpp
+++ b/ESPHamClock/ArduinoLib/Arduino.cpp
@@ -17,6 +17,8 @@
 // max cpu usage, throttle with -t
 #define DEF_CPU_USAGE 0.8F
 static float max_cpu_usage = DEF_CPU_USAGE;
+// even at 100% throttle, don't busy-spin the host when loop() has nothing to do
+#define DEF_MIN_IDLE_LOOP_US 1000
 
 char **our_argv;                // our argv for restarting
 std::string our_dir;            // our storage directory, including trailing /
@@ -737,11 +739,21 @@ int main (int ac, char *av[])
     // this loop by itself would run 100% CPU so offer a means to be a better citizen and throttle back
     printf ("Starting Arduino loop()\n");
 
+    #define TVUSEC(tv0,tv1) (((tv1).tv_sec-(tv0).tv_sec)*1000000 + ((tv1).tv_usec-(tv0).tv_usec))
+
     if (max_cpu_usage == 1) {
 
-        // pure loop
-        for (;;)
+        // pure loop, but still yield briefly when loop() returns faster than our minimum idle cadence.
+        for (;;) {
+            struct timeval tv0;
+            gettimeofday (&tv0, NULL);
             loop();
+            struct timeval tv1;
+            gettimeofday (&tv1, NULL);
+            int loop_us = TVUSEC(tv0, tv1);
+            if (loop_us < DEF_MIN_IDLE_LOOP_US)
+                usleep (DEF_MIN_IDLE_LOOP_US - loop_us);
+        }
 
     } else {
 
@@ -750,8 +762,6 @@ int main (int ac, char *av[])
         int sleep_us = 100;             // initial sleep, usecs
         const int sleep_dt = 10;        // sleep adjustment, usecs
         const int max_sleep = 50000;    // max sleep each loop, usecs
-
-        #define TVUSEC(tv0,tv1) (((tv1).tv_sec-(tv0).tv_sec)*1000000 + ((tv1).tv_usec-(tv0).tv_usec))
 
         for (;;) {
 

--- a/ESPHamClock/ESPHamClock.cpp
+++ b/ESPHamClock/ESPHamClock.cpp
@@ -1038,6 +1038,7 @@ void newDX (LatLong &ll, const char grid[MAID_CHARLEN], const char *ovprefix)
 
     // enable great path unless very close to DE
     dxpath_time = ERAD_M * dx_ll.GSD(de_ll) > DEDX_MINPATH ? millis() : 0;
+    scheduleMapRedraw();
 
     // just call initEarthMap??
     drawDXInfo ();

--- a/ESPHamClock/ESPHamClock.cpp
+++ b/ESPHamClock/ESPHamClock.cpp
@@ -677,9 +677,6 @@ void loop()
         // update clocks
         updateClocks(false);
 
-        // update sat pass (this is just the pass; the path is recomputed before each map sweep)
-        updateSatPass();
-
         // display more of earth map
         drawMoreEarth();
 

--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -1462,6 +1462,7 @@ extern void drawMapCoord (uint16_t x, uint16_t y);
 extern void drawSun (void);
 extern void drawMoon (void);
 extern void drawDXInfo (void);
+extern uint16_t lazy_redraw_s;
 extern void scheduleMapRedraw (void);
 extern void ll2s (const LatLong &ll, SCoord &s, uint8_t edge);
 extern void ll2s (float lat, float lng, SCoord &s, uint8_t edge);

--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -1462,6 +1462,7 @@ extern void drawMapCoord (uint16_t x, uint16_t y);
 extern void drawSun (void);
 extern void drawMoon (void);
 extern void drawDXInfo (void);
+extern void scheduleMapRedraw (void);
 extern void ll2s (const LatLong &ll, SCoord &s, uint8_t edge);
 extern void ll2s (float lat, float lng, SCoord &s, uint8_t edge);
 extern void ll2sRaw (const LatLong &ll, SCoord &s, uint8_t edge);

--- a/ESPHamClock/adif.cpp
+++ b/ESPHamClock/adif.cpp
@@ -85,6 +85,7 @@ static bool showing_set_adif;                           // set when not checking
 static bool newfile_pending;                            // set when find new file while scrolled away
 static FileSignature fsig;                              // used to decide whether to read file again
 static int n_adif_bad;                                  // n bad spots found, global to maintain context
+static uint32_t adif_generation;                        // increment whenever adif_spots is reloaded
 
 
 /* save sort and file name
@@ -391,6 +392,7 @@ void loadADIFFile (GenReader &gr, int &n_good, int &n_bad)
 
     // note new source type ready
     showing_set_adif = gr.isClient();
+    adif_generation++;
     
     // final message
     mapMsg (1000, "Loaded ADIF file");
@@ -412,7 +414,10 @@ void updateADIF (const SBox &box, bool refresh)
     }
 
     // check for changed file
+    uint32_t prev_generation = adif_generation;
     freshenADIFFile();
+    if (adif_generation != prev_generation && findPaneForChoice(PLOT_CH_ADIF) != PANE_NONE)
+        scheduleMapRedraw();
 
     // update symbol and hold
     adif_ss.drawNewSpotsSymbol (newfile_pending, false);

--- a/ESPHamClock/dxcluster.cpp
+++ b/ESPHamClock/dxcluster.cpp
@@ -1009,11 +1009,14 @@ bool updateDXCluster (const SBox &box, bool fresh)
 
     if (dxc_ss.atNewest()) {
         // rebuild displayed spots list when master list changes or oldest spot ages out
-        if (dxc_spots_changed || (n_dxspots > 0 && dxc_spots[0].spotted < myNow() - MAXKEEP_DT)) {
+        bool map_spots_changed = dxc_spots_changed;
+        if (map_spots_changed || (n_dxspots > 0 && dxc_spots[0].spotted < myNow() - MAXKEEP_DT)) {
             rebuildDXWatchList();
             dxc_spots_changed = false;
             dxc_ss.drawNewSpotsSymbol (false, false);           // insure off
             scrolledaway_tm = 0;
+            if (map_spots_changed && findPaneForChoice(PLOT_CH_DXCLUSTER) != PANE_NONE)
+                scheduleMapRedraw();
         }
         ROTHOLD_CLR(PLOT_CH_DXCLUSTER);                         // resume rotation
     } else {

--- a/ESPHamClock/dxcluster.cpp
+++ b/ESPHamClock/dxcluster.cpp
@@ -1015,7 +1015,7 @@ bool updateDXCluster (const SBox &box, bool fresh)
             dxc_spots_changed = false;
             dxc_ss.drawNewSpotsSymbol (false, false);           // insure off
             scrolledaway_tm = 0;
-            if (map_spots_changed && findPaneForChoice(PLOT_CH_DXCLUSTER) != PANE_NONE)
+            if (findPaneForChoice(PLOT_CH_DXCLUSTER) != PANE_NONE)
                 scheduleMapRedraw();
         }
         ROTHOLD_CLR(PLOT_CH_DXCLUSTER);                         // resume rotation

--- a/ESPHamClock/dxpeds.cpp
+++ b/ESPHamClock/dxpeds.cpp
@@ -57,6 +57,7 @@ static DXPCredit *credits;                      // malloced list of each credit
 static int n_credits;                           // n credits
 static ADIFWList *adif_worked;                  // malloced list of ADIF worked band+mode
 static int n_adif_worked;                       // n adif_worked[]
+static bool dxpeds_spots_changed;               // set when dxcluster spot state changes map markers
 
 
 // NV_DXPEDS bits
@@ -822,8 +823,14 @@ bool updateDXPeds (const SBox &box, bool fresh)
             }
         }
 
-        if (checkActiveDXPeds() || fresh)
+        bool markers_changed = checkActiveDXPeds() || fresh;
+        if (markers_changed)
             drawDXPedsPane (box);
+
+        if ((markers_changed || dxpeds_spots_changed) && findPaneForChoice(PLOT_CH_DXPEDS) != PANE_NONE) {
+            scheduleMapRedraw();
+            dxpeds_spots_changed = false;
+        }
 
     } else {
 
@@ -995,8 +1002,10 @@ bool getClosestDXPed (LatLong &ll, DXPedEntry *&dxp)
  */
 void tellDXPedsSpotChanged (void)
 {
-    if (findPaneForChoice (PLOT_CH_DXPEDS) != PANE_NONE && dxp_ss.atNewest())
+    if (findPaneForChoice (PLOT_CH_DXPEDS) != PANE_NONE && dxp_ss.atNewest()) {
+        dxpeds_spots_changed = true;
         scheduleNewPlot (PLOT_CH_DXPEDS);
+    }
 }
 
 

--- a/ESPHamClock/earthmap.cpp
+++ b/ESPHamClock/earthmap.cpp
@@ -39,12 +39,30 @@ uint8_t show_lp;                                // display long path, else short
 #define GRAYLINE_COS    (-0.208F)               // cos(90 + grayline angle), we use 12 degs
 #define GRAYLINE_POW    (0.75F)                 // cos power exponent, sqrt is too severe, 1 is too gradual
 static SCoord moremap_s;                        // drawMoreEarth() scanning location 
+static bool moremap_active;                     // whether a map sweep is currently in progress
+static uint32_t moremap_generation;             // incremented whenever a new sweep is explicitly scheduled
+static uint32_t next_redraw_ms;                 // next periodic redraw deadline once a sweep completes
+#define EARTH_REDRAW_INTERVAL_MS 1000U          // redraw slow-changing map overlays at a modest cadence
 
 // cached grid colors
 uint16_t EARTH_GRIDC, EARTH_GRIDC00;            // main and highlighted
 
 // flag to defer drawing over map until opportune time:
 bool mapmenu_pending;
+
+static void updateCircumstances();
+
+/* request a fresh visual sweep of the current map without reloading its source data.
+ * used to clear old overlays and redraw moving symbols on demand.
+ */
+void scheduleMapRedraw (void)
+{
+    moremap_s.x = 0;
+    moremap_s.y = map_b.y;
+    moremap_active = true;
+    next_redraw_ms = 0;
+    moremap_generation++;
+}
 
 // grid spacing, degrees
 #define LL_LAT_GRID     15
@@ -964,18 +982,35 @@ void initEarthMap()
     updateZoneSCoords(ZONE_CQ);
     updateZoneSCoords(ZONE_ITU);
 
-    // init scan line in map_b
-    moremap_s.x = 0;                    // avoid updateCircumstances() first call to drawMoreEarth()
-    moremap_s.y = map_b.y;
-
     // now main loop can resume with drawMoreEarth()
+    scheduleMapRedraw();
 }
 
 /* display another earth map row at mmoremap_s.
  */
 void drawMoreEarth()
 {
+    if (!moremap_active) {
+        // Only consume deferred overlays while the map is stable. If a redraw is
+        // due now, leave them pending so the fresh map does not immediately paint
+        // over them before the end-of-sweep handlers run.
+        if ((int32_t)(millis() - next_redraw_ms) < 0) {
+            if (mapmenu_pending) {
+                drawMapMenu();
+                mapmenu_pending = false;
+            }
+            if (map_popup.pending) {
+                drawMapPopup();
+                map_popup.pending = false;
+            }
+            return;
+        }
 
+        updateCircumstances();
+        scheduleMapRedraw();
+    }
+
+    uint32_t sweep_generation = moremap_generation;
     uint16_t last_x = map_b.x + EARTH_W - 1;
 
     // draw next row
@@ -1013,9 +1048,13 @@ void drawMoreEarth()
         // rotate?
         checkBGMap();
 
-        // prep for next
-        updateCircumstances();
-        moremap_s.y = map_b.y;
+        // a menu action or map refresh may have already restarted the sweep.
+        if (moremap_generation != sweep_generation)
+            return;
+
+        // otherwise stop here and wait until the next periodic or explicit redraw request.
+        moremap_active = false;
+        next_redraw_ms = millis() + EARTH_REDRAW_INTERVAL_MS;
 
     // #define TIME_MAP_DRAW                             // RBF
     #if defined(TIME_MAP_DRAW)

--- a/ESPHamClock/earthmap.cpp
+++ b/ESPHamClock/earthmap.cpp
@@ -42,7 +42,6 @@ static SCoord moremap_s;                        // drawMoreEarth() scanning loca
 static bool moremap_active;                     // whether a map sweep is currently in progress
 static uint32_t moremap_generation;             // incremented whenever a new sweep is explicitly scheduled
 static uint32_t next_redraw_ms;                 // next periodic redraw deadline once a sweep completes
-#define EARTH_REDRAW_INTERVAL_MS 1000U          // redraw slow-changing map overlays at a modest cadence
 
 // cached grid colors
 uint16_t EARTH_GRIDC, EARTH_GRIDC00;            // main and highlighted
@@ -52,16 +51,21 @@ bool mapmenu_pending;
 
 static void updateCircumstances();
 
-/* request a fresh visual sweep of the current map without reloading its source data.
- * used to clear old overlays and redraw moving symbols on demand.
- */
-void scheduleMapRedraw (void)
+static void startMapRedraw (void)
 {
     moremap_s.x = 0;
     moremap_s.y = map_b.y;
     moremap_active = true;
     next_redraw_ms = 0;
     moremap_generation++;
+}
+
+/* request a fresh visual sweep of the current map without reloading its source data.
+ * used to clear old overlays and redraw moving symbols on demand.
+ */
+void scheduleMapRedraw (void)
+{
+    startMapRedraw ();
 }
 
 // grid spacing, degrees
@@ -1007,7 +1011,7 @@ void drawMoreEarth()
         }
 
         updateCircumstances();
-        scheduleMapRedraw();
+        startMapRedraw ();
     }
 
     uint32_t sweep_generation = moremap_generation;
@@ -1052,9 +1056,14 @@ void drawMoreEarth()
         if (moremap_generation != sweep_generation)
             return;
 
-        // otherwise stop here and wait until the next periodic or explicit redraw request.
-        moremap_active = false;
-        next_redraw_ms = millis() + EARTH_REDRAW_INTERVAL_MS;
+        // either keep sweeping continuously or pause until the next lazy redraw deadline.
+        if (lazy_redraw_s == 0) {
+            updateCircumstances();
+            moremap_s.y = map_b.y;
+        } else {
+            moremap_active = false;
+            next_redraw_ms = millis() + 1000UL*lazy_redraw_s;
+        }
 
     // #define TIME_MAP_DRAW                             // RBF
     #if defined(TIME_MAP_DRAW)

--- a/ESPHamClock/lightning.cpp
+++ b/ESPHamClock/lightning.cpp
@@ -312,8 +312,11 @@ void drawNCDXFLightningStats (void)
  */
 void resetLightning (void)
 {
+    bool had_strikes = n_strikes > 0;
     n_strikes  = 0;
     next_fetch = 0;
+    if (had_strikes || lightning_on)
+        scheduleMapRedraw();
 }
 
 /* Restore NV state at startup.
@@ -355,9 +358,10 @@ void updateLightning (void)
     if (now < next_fetch)
         return;
 
-    if (fetchLightning())
+    if (fetchLightning()) {
         next_fetch = now + LIGHTNING_INTERVAL;
-    else
+        scheduleMapRedraw();
+    } else
         next_fetch = now + LIGHTNING_RETRY_SECS;
 }
 

--- a/ESPHamClock/ontheair.cpp
+++ b/ESPHamClock/ontheair.cpp
@@ -673,19 +673,25 @@ bool updateOnTheAir (const SBox &box, bool fresh)
 
     // always update raw onta_spots, but don't transfer to ontawl_spots if scrolled away
 
+    uint32_t prev_hash = spots_hash;
     bool ok = retrieveONTA();
     if (ok) {
         spots_hash = spotsHash (onta_spots, n_ontaspots);
         if (onta_ss.atNewest()) {
+            bool rotated_org = false;
             if (onta_norgs > 0 && !onta_merge) {
                 // rotate to next org
                 next_ontaorg = (next_ontaorg + 1) % onta_norgs; // rotate org
+                rotated_org = true;
                 Serial.printf ("ONTA: now showing %s\n", onta_orgs[next_ontaorg]);
             }
             rebuildONTAWatchList();
             onta_ss.drawNewSpotsSymbol (false, false);                  // New symbol off
             ROTHOLD_CLR(PLOT_CH_ONTA);                                  // release rotation hold
             drawONTAPane (box);
+            if (findPaneForChoice(PLOT_CH_ONTA) != PANE_NONE
+                    && (fresh || rotated_org || spots_hash != prev_hash))
+                scheduleMapRedraw();
         } else {
             onta_ss.drawNewSpotsSymbol (NEW_SPOTS(), false);            // on if different
             ROTHOLD_SET(PLOT_CH_ONTA);                                  // hold rotation

--- a/ESPHamClock/pskreporter.cpp
+++ b/ESPHamClock/pskreporter.cpp
@@ -443,6 +443,9 @@ bool updatePSKReporter (const SBox &box, bool force)
     // display whatever we got regardless
     drawPSKPane (box);
 
+    if (last_ok && findPaneForChoice(PLOT_CH_PSK) != PANE_NONE)
+        scheduleMapRedraw();
+
     // reply
     return (last_ok);
 }

--- a/ESPHamClock/wifi.cpp
+++ b/ESPHamClock/wifi.cpp
@@ -2501,6 +2501,7 @@ void scheduleNewCoreMap (CoreMaps cm)
 void scheduleFreshMap (void)
 {
     next_map = 0;
+    scheduleMapRedraw();
 }
 
 /* return current NTP response time list.

--- a/ESPHamClock/wifi.cpp
+++ b/ESPHamClock/wifi.cpp
@@ -87,6 +87,7 @@ static NTPServer ntp_list[] = {                 // init times to 0 insures all g
 // web site retry interval and max, secs
 #define WIFI_RETRY      (15)
 #define WIFI_MAXRETRY   (5*60)
+#define WIFI_MAINT_MS   100U                    // outer gate for pane/RSS/lightning maintenance
 
 /* "reverting" refers to restoring PANE_1 after temporarily forced to show DE or DX weather.
  */
@@ -2086,6 +2087,12 @@ bool checkBCTouch (const SCoord &s, const SBox &b)
  */
 void updateWiFi(void)
 {
+    static uint32_t maint_ms;
+    if (!timesUp(&maint_ms, WIFI_MAINT_MS)) {
+        // Keep server commands responsive while deferring the slower pane maintenance work.
+        checkWebServer(false);
+        return;
+    }
 
     // time now
     time_t t0 = myNow();

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This repository was started with the source code for Clear Sky Institute's HamCl
 
 An archive of historical HamClock Client releases up to 4.22 is available at <https://github.com/openhamclock/hamclock-client-archive>.
 
+This fork also carries a few changes by YO3GND which reduce CPU load in the desktop/web build without slowing background polling or delaying map-visible updates. The practical result is that you can leave it running in Docker without the machine sounding as though it is preparing for take-off, and use something else to warm the room.
+
+To check it out, run `docker run -d --name hamclock -p 8080:8080 -p 8081:8081 -p 8082:8082 yo3gnd/hamclock:latest`.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at

--- a/doc/cli/README.md
+++ b/doc/cli/README.md
@@ -17,6 +17,7 @@ The following command line options are defined:
     -i i : init DE using geolocation with IP i; requires -k
     -k   : start in normal mode, ie, don't offer Setup or wait for Skips
     -l l : set Mercator or Robinson center longitude to l degrees, +E; requires -k
+    -L s : set idle map redraw interval to s seconds; 0 keeps continuous redraw; default 30
     -m   : enable demo mode
     -n t : set live web idle timeout to t minutes; default forever
     -o   : write diagnostic log to stdout instead of in ~/.hamclock/

--- a/doc/cli/README.md
+++ b/doc/cli/README.md
@@ -17,7 +17,7 @@ The following command line options are defined:
     -i i : init DE using geolocation with IP i; requires -k
     -k   : start in normal mode, ie, don't offer Setup or wait for Skips
     -l l : set Mercator or Robinson center longitude to l degrees, +E; requires -k
-    -L s : set idle map redraw interval to s seconds; 0 keeps continuous redraw; default 30
+    -L s : set idle map redraw interval to s seconds [0,600]; 0 keeps continuous redraw; values above 600 are capped; default 30
     -m   : enable demo mode
     -n t : set live web idle timeout to t minutes; default forever
     -o   : write diagnostic log to stdout instead of in ~/.hamclock/


### PR DESCRIPTION
Fixes #121.

Hamclock's high CPU on desktop/web turned out to be less about useful work and more about repainting the world forever.. After each earth sweep completed, the next one began immediately, even if nothing had changed. Pane-driven overlays only looked event-driven because another sweep was always imminent.

This PR makes passive map redraw lazy by default and explicit when something map-visible actually changes. The aim is conservative: remove needless steady-state work without redesigning the renderer or changing storage.

## What changed

- add `-L secs` to control idle map redraw cadence; default `30`, `0` keeps the old eager behaviour, and values above `600` are capped with a warning
- stop immediately restarting the earth sweep after every completed pass unless `-L 0` is selected
- schedule immediate redraws for map-visible updates from `newDX()`, ADIF, OTA, DX Cluster, dxpeditions, PSK, lightning, and explicit background refreshes
- keep deferred map menus/popups from being drawn just in time to be painted over by the next sweep
- remove one duplicate `updateSatPass()` call from the main loop
- outer-gate pane/RSS/lightning maintenance to `100 ms` while keeping the web command path fast

## Why this shape

This is the implementation proposed in #121 reduce steady-state redraw churn first, rather than leaning on -t.

`-t` is a mitigation, not a fix. It lowers CPU by injecting sleep into the same loop that also handles redraw, touch, and web work, so under load it buys headroom by buying latency. #120 feels adjacent in spirit: blunt loop caps and checks are easy enough to add, but they are not free, and they can alter behaviour in awkward places. This PR goes the other way and removes needless steady-state work first.

## Measurements

Local 3-minute benchmark, web build, same backend/state, `-t 100`, no live client attached (it renders continuously, even without a client). The first 15 seconds are excluded:

- `main`: about `71.15%` CPU
- after the structural redraw fix: about `4.12%`
- after the duplicate sat-pass cleanup: about `4.16%` (I'll call it noise)
- after the `100 ms` Wi-Fi maintenance fix: about `3.99%`
- after lazy redraw with default `-L 30`: about `1.82%`
- after overlay-triggered redraw hooks: about `1.84%`

So the final branch is about `97%` below the master in that local steady-state test, while `-L 0` still preserves eager behaviour for anyone who wants the old repaint cadence.

## Notes

- this does **not** try to build a full invalidation engine; it is intentionally small and a bit boring.
- the edge cases exposed by lazy redraw are handled here too: explicit `scheduleFreshMap()` actions now start a sweep immediately, and DX cluster age-out now redraws promptly instead of waiting for the next passive sweep
- there is probably more headroom later if anyone wants it. In particular, we do not need to redraw the sun and greyline every second just to prove that the sun is, in fact, still moving. There are easier ways to keep tabs on the thing, and most of them do not involve burning CPU.