### PR TITLE
Fix hot-path redraw churn

### DIFF
--- a/ESPHamClock/ArduinoLib/Arduino.cpp
+++ b/ESPHamClock/ArduinoLib/Arduino.cpp
@@ -17,6 +17,8 @@
 // max cpu usage, throttle with -t
 #define DEF_CPU_USAGE 0.8F
 static float max_cpu_usage = DEF_CPU_USAGE;
+// even at 100% throttle, don't busy-spin the host when loop() has nothing to do
+#define DEF_MIN_IDLE_LOOP_US 1000
 
 char **our_argv;                // our argv for restarting
 std::string our_dir;            // our storage directory, including trailing /
@@ -737,11 +739,21 @@ int main (int ac, char *av[])
     // this loop by itself would run 100% CPU so offer a means to be a better citizen and throttle back
     printf ("Starting Arduino loop()\n");
 
+    #define TVUSEC(tv0,tv1) (((tv1).tv_sec-(tv0).tv_sec)*1000000 + ((tv1).tv_usec-(tv0).tv_usec))
+
     if (max_cpu_usage == 1) {
 
-        // pure loop
-        for (;;)
+        // pure loop, but still yield briefly when loop() returns faster than our minimum idle cadence.
+        for (;;) {
+            struct timeval tv0;
+            gettimeofday (&tv0, NULL);
             loop();
+            struct timeval tv1;
+            gettimeofday (&tv1, NULL);
+            int loop_us = TVUSEC(tv0, tv1);
+            if (loop_us < DEF_MIN_IDLE_LOOP_US)
+                usleep (DEF_MIN_IDLE_LOOP_US - loop_us);
+        }
 
     } else {
 
@@ -750,8 +762,6 @@ int main (int ac, char *av[])
         int sleep_us = 100;             // initial sleep, usecs
         const int sleep_dt = 10;        // sleep adjustment, usecs
         const int max_sleep = 50000;    // max sleep each loop, usecs
-
-        #define TVUSEC(tv0,tv1) (((tv1).tv_sec-(tv0).tv_sec)*1000000 + ((tv1).tv_usec-(tv0).tv_usec))
 
         for (;;) {
 

--- a/ESPHamClock/ESPHamClock.cpp
+++ b/ESPHamClock/ESPHamClock.cpp
@@ -1038,6 +1038,7 @@ void newDX (LatLong &ll, const char grid[MAID_CHARLEN], const char *ovprefix)
 
     // enable great path unless very close to DE
     dxpath_time = ERAD_M * dx_ll.GSD(de_ll) > DEDX_MINPATH ? millis() : 0;
+    scheduleMapRedraw();
 
     // just call initEarthMap??
     drawDXInfo ();

--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -1463,6 +1463,8 @@ extern void drawSun (void);
 extern void drawMoon (void);
 extern void drawDXInfo (void);
 extern void scheduleMapRedraw (void);
+extern void mm_redraw(void);
+extern bool mm_up (void);
 extern void ll2s (const LatLong &ll, SCoord &s, uint8_t edge);
 extern void ll2s (float lat, float lng, SCoord &s, uint8_t edge);
 extern void ll2sRaw (const LatLong &ll, SCoord &s, uint8_t edge);

--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -1462,6 +1462,7 @@ extern void drawMapCoord (uint16_t x, uint16_t y);
 extern void drawSun (void);
 extern void drawMoon (void);
 extern void drawDXInfo (void);
+extern void scheduleMapRedraw (void);
 extern void ll2s (const LatLong &ll, SCoord &s, uint8_t edge);
 extern void ll2s (float lat, float lng, SCoord &s, uint8_t edge);
 extern void ll2sRaw (const LatLong &ll, SCoord &s, uint8_t edge);

--- a/ESPHamClock/adif.cpp
+++ b/ESPHamClock/adif.cpp
@@ -85,6 +85,7 @@ static bool showing_set_adif;                           // set when not checking
 static bool newfile_pending;                            // set when find new file while scrolled away
 static FileSignature fsig;                              // used to decide whether to read file again
 static int n_adif_bad;                                  // n bad spots found, global to maintain context
+static uint32_t adif_generation;                        // increment whenever adif_spots is reloaded
 
 
 /* save sort and file name
@@ -391,6 +392,7 @@ void loadADIFFile (GenReader &gr, int &n_good, int &n_bad)
 
     // note new source type ready
     showing_set_adif = gr.isClient();
+    adif_generation++;
     
     // final message
     mapMsg (1000, "Loaded ADIF file");
@@ -412,7 +414,10 @@ void updateADIF (const SBox &box, bool refresh)
     }
 
     // check for changed file
+    uint32_t prev_generation = adif_generation;
     freshenADIFFile();
+    if (adif_generation != prev_generation && findPaneForChoice(PLOT_CH_ADIF) != PANE_NONE)
+        scheduleMapRedraw();
 
     // update symbol and hold
     adif_ss.drawNewSpotsSymbol (newfile_pending, false);

--- a/ESPHamClock/dxcluster.cpp
+++ b/ESPHamClock/dxcluster.cpp
@@ -1009,11 +1009,14 @@ bool updateDXCluster (const SBox &box, bool fresh)
 
     if (dxc_ss.atNewest()) {
         // rebuild displayed spots list when master list changes or oldest spot ages out
-        if (dxc_spots_changed || (n_dxspots > 0 && dxc_spots[0].spotted < myNow() - MAXKEEP_DT)) {
+        bool map_spots_changed = dxc_spots_changed;
+        if (map_spots_changed || (n_dxspots > 0 && dxc_spots[0].spotted < myNow() - MAXKEEP_DT)) {
             rebuildDXWatchList();
             dxc_spots_changed = false;
             dxc_ss.drawNewSpotsSymbol (false, false);           // insure off
             scrolledaway_tm = 0;
+            if (map_spots_changed && findPaneForChoice(PLOT_CH_DXCLUSTER) != PANE_NONE)
+                scheduleMapRedraw();
         }
         ROTHOLD_CLR(PLOT_CH_DXCLUSTER);                         // resume rotation
     } else {

--- a/ESPHamClock/dxcluster.cpp
+++ b/ESPHamClock/dxcluster.cpp
@@ -1015,7 +1015,7 @@ bool updateDXCluster (const SBox &box, bool fresh)
             dxc_spots_changed = false;
             dxc_ss.drawNewSpotsSymbol (false, false);           // insure off
             scrolledaway_tm = 0;
-            if (map_spots_changed && findPaneForChoice(PLOT_CH_DXCLUSTER) != PANE_NONE)
+            if (findPaneForChoice(PLOT_CH_DXCLUSTER) != PANE_NONE)
                 scheduleMapRedraw();
         }
         ROTHOLD_CLR(PLOT_CH_DXCLUSTER);                         // resume rotation

--- a/ESPHamClock/dxpeds.cpp
+++ b/ESPHamClock/dxpeds.cpp
@@ -57,6 +57,7 @@ static DXPCredit *credits;                      // malloced list of each credit
 static int n_credits;                           // n credits
 static ADIFWList *adif_worked;                  // malloced list of ADIF worked band+mode
 static int n_adif_worked;                       // n adif_worked[]
+static bool dxpeds_spots_changed;               // set when dxcluster spot state changes map markers
 
 
 // NV_DXPEDS bits
@@ -822,8 +823,14 @@ bool updateDXPeds (const SBox &box, bool fresh)
             }
         }
 
-        if (checkActiveDXPeds() || fresh)
+        bool markers_changed = checkActiveDXPeds() || fresh;
+        if (markers_changed)
             drawDXPedsPane (box);
+
+        if ((markers_changed || dxpeds_spots_changed) && findPaneForChoice(PLOT_CH_DXPEDS) != PANE_NONE) {
+            scheduleMapRedraw();
+            dxpeds_spots_changed = false;
+        }
 
     } else {
 
@@ -995,8 +1002,10 @@ bool getClosestDXPed (LatLong &ll, DXPedEntry *&dxp)
  */
 void tellDXPedsSpotChanged (void)
 {
-    if (findPaneForChoice (PLOT_CH_DXPEDS) != PANE_NONE && dxp_ss.atNewest())
+    if (findPaneForChoice (PLOT_CH_DXPEDS) != PANE_NONE && dxp_ss.atNewest()) {
+        dxpeds_spots_changed = true;
         scheduleNewPlot (PLOT_CH_DXPEDS);
+    }
 }
 
 

--- a/ESPHamClock/earthmap.cpp
+++ b/ESPHamClock/earthmap.cpp
@@ -39,12 +39,30 @@ uint8_t show_lp;                                // display long path, else short
 #define GRAYLINE_COS    (-0.208F)               // cos(90 + grayline angle), we use 12 degs
 #define GRAYLINE_POW    (0.75F)                 // cos power exponent, sqrt is too severe, 1 is too gradual
 static SCoord moremap_s;                        // drawMoreEarth() scanning location 
+static bool moremap_active;                     // whether a map sweep is currently in progress
+static uint32_t moremap_generation;             // incremented whenever a new sweep is explicitly scheduled
+static uint32_t next_redraw_ms;                 // next periodic redraw deadline once a sweep completes
+#define EARTH_REDRAW_INTERVAL_MS 1000U          // redraw slow-changing map overlays at a modest cadence
 
 // cached grid colors
 uint16_t EARTH_GRIDC, EARTH_GRIDC00;            // main and highlighted
 
 // flag to defer drawing over map until opportune time:
 bool mapmenu_pending;
+
+static void updateCircumstances();
+
+/* request a fresh visual sweep of the current map without reloading its source data.
+ * used to clear old overlays and redraw moving symbols on demand.
+ */
+void scheduleMapRedraw (void)
+{
+    moremap_s.x = 0;
+    moremap_s.y = map_b.y;
+    moremap_active = true;
+    next_redraw_ms = 0;
+    moremap_generation++;
+}
 
 // grid spacing, degrees
 #define LL_LAT_GRID     15
@@ -964,18 +982,35 @@ void initEarthMap()
     updateZoneSCoords(ZONE_CQ);
     updateZoneSCoords(ZONE_ITU);
 
-    // init scan line in map_b
-    moremap_s.x = 0;                    // avoid updateCircumstances() first call to drawMoreEarth()
-    moremap_s.y = map_b.y;
-
     // now main loop can resume with drawMoreEarth()
+    scheduleMapRedraw();
 }
 
 /* display another earth map row at mmoremap_s.
  */
 void drawMoreEarth()
 {
+    if (!moremap_active) {
+        // Only consume deferred overlays while the map is stable. If a redraw is
+        // due now, leave them pending so the fresh map does not immediately paint
+        // over them before the end-of-sweep handlers run.
+        if ((int32_t)(millis() - next_redraw_ms) < 0) {
+            if (mapmenu_pending) {
+                drawMapMenu();
+                mapmenu_pending = false;
+            }
+            if (map_popup.pending) {
+                drawMapPopup();
+                map_popup.pending = false;
+            }
+            return;
+        }
 
+        updateCircumstances();
+        scheduleMapRedraw();
+    }
+
+    uint32_t sweep_generation = moremap_generation;
     uint16_t last_x = map_b.x + EARTH_W - 1;
 
     // draw next row
@@ -1013,9 +1048,13 @@ void drawMoreEarth()
         // rotate?
         checkBGMap();
 
-        // prep for next
-        updateCircumstances();
-        moremap_s.y = map_b.y;
+        // a menu action or map refresh may have already restarted the sweep.
+        if (moremap_generation != sweep_generation)
+            return;
+
+        // otherwise stop here and wait until the next periodic or explicit redraw request.
+        moremap_active = false;
+        next_redraw_ms = millis() + EARTH_REDRAW_INTERVAL_MS;
 
     // #define TIME_MAP_DRAW                             // RBF
     #if defined(TIME_MAP_DRAW)

--- a/ESPHamClock/earthmap.cpp
+++ b/ESPHamClock/earthmap.cpp
@@ -42,7 +42,7 @@ static SCoord moremap_s;                        // drawMoreEarth() scanning loca
 static bool moremap_active;                     // whether a map sweep is currently in progress
 static uint32_t moremap_generation;             // incremented whenever a new sweep is explicitly scheduled
 static uint32_t next_redraw_ms;                 // next periodic redraw deadline once a sweep completes
-#define EARTH_REDRAW_INTERVAL_MS 1000U          // redraw slow-changing map overlays at a modest cadence
+#define EARTH_REDRAW_INTERVAL_MS 30000U         // redraw slow-changing map overlays at a conservative cadence
 
 // cached grid colors
 uint16_t EARTH_GRIDC, EARTH_GRIDC00;            // main and highlighted

--- a/ESPHamClock/earthmap.cpp
+++ b/ESPHamClock/earthmap.cpp
@@ -38,10 +38,14 @@ uint8_t show_lp;                                // display long path, else short
 
 #define GRAYLINE_COS    (-0.208F)               // cos(90 + grayline angle), we use 12 degs
 #define GRAYLINE_POW    (0.75F)                 // cos power exponent, sqrt is too severe, 1 is too gradual
-static SCoord moremap_s;                        // drawMoreEarth() scanning location 
+static SCoord moremap_s;                        // drawMoreEarth() scanning location
 static bool moremap_active;                     // whether a map sweep is currently in progress
 static uint32_t moremap_generation;             // incremented whenever a new sweep is explicitly scheduled
 static uint32_t next_redraw_ms;                 // next periodic redraw deadline once a sweep completes
+static bool mm_p;                              // mouse moved during a map sweep; redraw again when done
+static uint32_t mm_ms;                         // throttle mouse-driven city hover redraws
+static bool mp_a;                              // map popup menu currently running
+static bool mv_a;                              // map view menu currently running
 #define EARTH_REDRAW_INTERVAL_MS 30000U         // redraw slow-changing map overlays at a conservative cadence
 
 // cached grid colors
@@ -62,6 +66,29 @@ void scheduleMapRedraw (void)
     moremap_active = true;
     next_redraw_ms = 0;
     moremap_generation++;
+}
+
+
+
+void mm_redraw (void)
+{
+    uint32_t now_ms = millis();
+
+    // City hover is cursor-driven. Do not restart an active progressive map sweep;
+    // remember that another sweep is needed and start it as soon as the current one finishes.
+    if (now_ms - mm_ms < 33U || moremap_active) {
+        mm_p = true;
+        return;
+    }
+
+    mm_p = false;
+    scheduleMapRedraw();
+    mm_ms = now_ms;
+}
+
+bool mm_up (void)
+{
+    return (mp_a || mv_a);
 }
 
 // grid spacing, degrees
@@ -363,7 +390,10 @@ static void drawMapPopup(void)
 
     // go
     MenuInfo menu = {menu_b, ok_b, UF_CLOCKSOK, M_CANCELOK, 1, n_menu, mitems};
-    if (runMenu (menu)) {
+    mp_a = true;
+    bool ok = runMenu (menu);
+    mp_a = false;
+    if (ok) {
 
 
         // init copy for changes
@@ -823,9 +853,11 @@ static void drawMapMenu()
     // run menu
     SBox ok_b;
     MenuInfo menu = {menu_b, ok_b, UF_CLOCKSOK, M_CANCELOK, 1, MI_N, mitems};
-    bool menu_ok = runMenu (menu);
+    mv_a = true;
+    bool ok = runMenu (menu);
+    mv_a = false;
 
-    if (menu_ok) {
+    if (ok) {
 
 
         // build new map_rotset
@@ -991,10 +1023,14 @@ void initEarthMap()
 void drawMoreEarth()
 {
     if (!moremap_active) {
+        uint32_t now_ms = millis();
+        bool mm_due = mm_p && now_ms - mm_ms >= 33U;
+        bool map_due = (int32_t)(now_ms - next_redraw_ms) >= 0;
+
         // Only consume deferred overlays while the map is stable. If a redraw is
         // due now, leave them pending so the fresh map does not immediately paint
         // over them before the end-of-sweep handlers run.
-        if ((int32_t)(millis() - next_redraw_ms) < 0) {
+        if (!mm_due && !map_due) {
             if (mapmenu_pending) {
                 drawMapMenu();
                 mapmenu_pending = false;
@@ -1006,6 +1042,10 @@ void drawMoreEarth()
             return;
         }
 
+        if (mm_due) {
+            mm_p = false;
+            mm_ms = now_ms;
+        }
         updateCircumstances();
         scheduleMapRedraw();
     }
@@ -1054,6 +1094,12 @@ void drawMoreEarth()
 
         // otherwise stop here and wait until the next periodic or explicit redraw request.
         moremap_active = false;
+
+        if (mm_p) {
+            mm_p = false;
+            mm_ms = millis();
+            scheduleMapRedraw();
+        }
         next_redraw_ms = millis() + EARTH_REDRAW_INTERVAL_MS;
 
     // #define TIME_MAP_DRAW                             // RBF

--- a/ESPHamClock/infobox.cpp
+++ b/ESPHamClock/infobox.cpp
@@ -132,7 +132,6 @@ static bool drawIB_Mode (const char *mode, uint16_t tx, int dy, uint16_t &ty)
 
 /* drawMouseLoc() helper for looking up city.
  * if city is wanted, found and over map: change ll, ms and names_w IN PLACE and draw dot and name
- * N.B. we assume the city name background is already erased
  */
 static bool drawIB_City (LatLong &ll, SCoord &ms, const SBox &info_b, uint16_t &names_w, uint16_t names_y)
 {
@@ -157,9 +156,12 @@ static bool drawIB_City (LatLong &ll, SCoord &ms, const SBox &info_b, uint16_t &
                 ll = city_ll;
                 ms = city_ms;
                 names_w = max_cl * 6;           // * font width
+                uint16_t names_x = map_b.x + (map_b.w-names_w)/2;
                 // dot
                 tft.fillCircle (city_ms.x, city_ms.y, CDOT_R, RA8875_RED);
-                // name, assuming background is already erased
+                // name background
+                tft.fillRect (names_x, names_y, names_w, 14, RA8875_BLACK);
+                // name
                 uint16_t c_w = getTextWidth (city);
                 tft.setCursor (map_b.x + (map_b.w-c_w)/2, names_y + 3);
                 tft.print(city);

--- a/ESPHamClock/lightning.cpp
+++ b/ESPHamClock/lightning.cpp
@@ -312,8 +312,11 @@ void drawNCDXFLightningStats (void)
  */
 void resetLightning (void)
 {
+    bool had_strikes = n_strikes > 0;
     n_strikes  = 0;
     next_fetch = 0;
+    if (had_strikes || lightning_on)
+        scheduleMapRedraw();
 }
 
 /* Restore NV state at startup.
@@ -355,9 +358,10 @@ void updateLightning (void)
     if (now < next_fetch)
         return;
 
-    if (fetchLightning())
+    if (fetchLightning()) {
         next_fetch = now + LIGHTNING_INTERVAL;
-    else
+        scheduleMapRedraw();
+    } else
         next_fetch = now + LIGHTNING_RETRY_SECS;
 }
 

--- a/ESPHamClock/liveweb.cpp
+++ b/ESPHamClock/liveweb.cpp
@@ -647,9 +647,28 @@ static void setLiveMouse (ws_cli_conn_t *client, char args[], size_t args_len)
     } else {
 
         // set
+        static int lx = -1;
+        static int ly = -1;
+        static bool lom;
+
         int x = atoi(wa.value[0]);
         int y = atoi(wa.value[1]);
         tft.setMouse (x, y);
+
+        SCoord ms = { (uint16_t)x, (uint16_t)y };
+        bool om = overMap(ms);
+        bool mv = x != lx || y != ly;
+
+        // City names/red dot are driven by mouse position, not by overlay data updates.
+        // Since the normal map redraw interval is now long, explicitly redraw the map
+        // when the cursor moves over the map, or leaves it, so the old city marker clears.
+        if (mv && mainpage_up && names_on && !mm_up() && (om || lom))
+            mm_redraw();
+
+        lx = x;
+        ly = y;
+        lom = om;
+
         if (debugLevel (DEBUG_WEB, 1))
             Serial.printf ("LIVE: set_mouse %d %d\n", x, y);
             

--- a/ESPHamClock/menu.cpp
+++ b/ESPHamClock/menu.cpp
@@ -782,6 +782,11 @@ bool runMenu (MenuInfo &menu)
     if (!tft.setBackingStore (backing_store, menu.menu_b.x, menu.menu_b.y, menu.menu_b.w, menu.menu_b.h))
         fatalError ("mem pixel restore failed %d x %d", menu.menu_b.w, menu.menu_b.h);
 
+    // If the menu was over the map, publish the restored pixels immediately.
+    // On lazy redraw paths, otherwise the browser can still be looking at a dead menu.
+    if (boxesOverlap (menu.menu_b, map_b))
+        tft.drawPR();
+
     // record settings
     Serial.printf ("Menu result after %s:\n", ok ? "Ok" : "Cancel");
     for (int i = 0; i < menu.n_items; i++) {

--- a/ESPHamClock/ontheair.cpp
+++ b/ESPHamClock/ontheair.cpp
@@ -673,19 +673,25 @@ bool updateOnTheAir (const SBox &box, bool fresh)
 
     // always update raw onta_spots, but don't transfer to ontawl_spots if scrolled away
 
+    uint32_t prev_hash = spots_hash;
     bool ok = retrieveONTA();
     if (ok) {
         spots_hash = spotsHash (onta_spots, n_ontaspots);
         if (onta_ss.atNewest()) {
+            bool rotated_org = false;
             if (onta_norgs > 0 && !onta_merge) {
                 // rotate to next org
                 next_ontaorg = (next_ontaorg + 1) % onta_norgs; // rotate org
+                rotated_org = true;
                 Serial.printf ("ONTA: now showing %s\n", onta_orgs[next_ontaorg]);
             }
             rebuildONTAWatchList();
             onta_ss.drawNewSpotsSymbol (false, false);                  // New symbol off
             ROTHOLD_CLR(PLOT_CH_ONTA);                                  // release rotation hold
             drawONTAPane (box);
+            if (findPaneForChoice(PLOT_CH_ONTA) != PANE_NONE
+                    && (fresh || rotated_org || spots_hash != prev_hash))
+                scheduleMapRedraw();
         } else {
             onta_ss.drawNewSpotsSymbol (NEW_SPOTS(), false);            // on if different
             ROTHOLD_SET(PLOT_CH_ONTA);                                  // hold rotation

--- a/ESPHamClock/pskreporter.cpp
+++ b/ESPHamClock/pskreporter.cpp
@@ -443,6 +443,9 @@ bool updatePSKReporter (const SBox &box, bool force)
     // display whatever we got regardless
     drawPSKPane (box);
 
+    if (last_ok && findPaneForChoice(PLOT_CH_PSK) != PANE_NONE)
+        scheduleMapRedraw();
+
     // reply
     return (last_ok);
 }

--- a/ESPHamClock/touch.cpp
+++ b/ESPHamClock/touch.cpp
@@ -103,6 +103,9 @@ void drainTouch()
     while (tft.touched())
         tft.touchRead (&tx, &ty, NULL);
 
+    wifi_tt = TT_NONE;
+    wifi_tt_s = {0, 0};
+
     bool control, shift;
     while (tft.getChar (&control, &shift) != CHAR_NONE)
         continue;

--- a/ESPHamClock/wifi.cpp
+++ b/ESPHamClock/wifi.cpp
@@ -2494,6 +2494,7 @@ void scheduleNewCoreMap (CoreMaps cm)
 void scheduleFreshMap (void)
 {
     next_map = 0;
+    scheduleMapRedraw();
 }
 
 /* return current NTP response time list.


### PR DESCRIPTION
This is the main slice of the original broader CPU/load PR #122 - split out for easier review. This branch contains only the core redraw/runtime change and fixes #121 

It keeps the core redraw/runtime change together: stop the continuous repaint loop, preserve prompt redraws where the old code had been relying on “another sweep will happen in a moment anyway”, and keep a conservative periodic refresh for slow-moving overlays. The -L knob and the two tiny follow-up cleanups are left to separate branches so this one stays focused on the main behavioural fix.