### PR TITLE
Add CI compile checks for web and fb0 targets

### DIFF
--- a/.github/workflows/compile-fb0.yml
+++ b/.github/workflows/compile-fb0.yml
@@ -1,0 +1,37 @@
+name: Compile Pi targets
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fb0:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    container: alpine:3.23
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - hamclock-fb0-800x480
+          - hamclock-fb0-1600x960
+          - hamclock-fb0-2400x1440
+          - hamclock-fb0-3200x1920
+
+    steps:
+      - name: Install dependencies
+        run: apk add --no-cache git build-base linux-headers
+
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Compile ${{ matrix.target }}
+        working-directory: ESPHamClock
+        run: make -j"$(nproc)" "${{ matrix.target }}"

--- a/.github/workflows/compile-web.yml
+++ b/.github/workflows/compile-web.yml
@@ -1,0 +1,37 @@
+name: Compile web targets
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  web:
+    name: web ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    container: alpine:3.23
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - hamclock-web-800x480
+          - hamclock-web-1600x960
+          - hamclock-web-2400x1440
+          - hamclock-web-3200x1920
+
+    steps:
+      - name: Install dependencies
+        run: apk add --no-cache git build-base
+
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Compile ${{ matrix.target }}
+        working-directory: ESPHamClock
+        run: make -j"$(nproc)" "${{ matrix.target }}"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HamClock Client
 
+[![C++11 web](https://img.shields.io/github/actions/workflow/status/openhamclock/hamclock/compile-web.yml?branch=main&label=C%2B%2B11%20web&logo=cplusplus&style=flat)](https://github.com/openhamclock/hamclock/actions/workflows/compile-web.yml) [![C++11 Pi](https://img.shields.io/github/actions/workflow/status/openhamclock/hamclock/compile-fb0.yml?branch=main&label=C%2B%2B11%20Pi&logo=raspberrypi&style=flat)](https://github.com/openhamclock/hamclock/actions/workflows/compile-fb0.yml)
+
 This repository is the primary source for ongoing maintenance of the HamClock Client,
 aka the HamClock "frontend", and often just referred to as "HamClock".
 


### PR DESCRIPTION
Adds two compile-smoke workflows: one for the stock web targets, one for the stock fb0 builds. No tests yet, just the modest claim that ohc still compiles.
