### PR TITLE
lightning data isn't all old to new - process in three passes

### DIFF
--- a/ESPHamClock/lightning.cpp
+++ b/ESPHamClock/lightning.cpp
@@ -465,36 +465,36 @@ void drawLightningOnMap (void)
         return;
 
     for (int ageloop = 0; ageloop < 3; ageloop++) {  // age in loop goes from oldest 0 to newest 2
-		for (int i = 0; i < n_strikes; i++) {
+        for (int i = 0; i < n_strikes; i++) {
 
-			SCoord s;
-			ll2sRaw (strikes[i].lat * (M_PIF / 180.0F),
-					strikes[i].lng * (M_PIF / 180.0F),
-					s, 8);
+            SCoord s;
+            ll2sRaw (strikes[i].lat * (M_PIF / 180.0F),
+                    strikes[i].lng * (M_PIF / 180.0F),
+                    s, 8);
 
-			if (s.x == 0 && s.y == 0)
-				continue;
+            if (s.x == 0 && s.y == 0)
+                continue;
 
-			// Don't draw over the RSS banner
-			if (overRSS (raw2appSCoord (s)))
-				continue;
+            // Don't draw over the RSS banner
+            if (overRSS (raw2appSCoord (s)))
+                continue;
 
-			int myage;
-			uint16_t color;
-			if      (strikes[i].age_s < 120) {
-				color = RGB565(255, 220,   0);
-				myage=2;
-			}
-			else if (strikes[i].age_s < 300)  {
-				color = RGB565(255, 140,   0);
-				myage=1;
-			}
-			else {
-				color = RGB565(220,  40,  40);
-				myage=0;
-			}
-			if (ageloop == myage)
-				drawBolt ((int16_t)s.x, (int16_t)s.y, color);
-		}
-	}
+            int myage;
+            uint16_t color;
+            if      (strikes[i].age_s < 120) {
+                color = RGB565(255, 220,   0);
+                myage=2;
+            }
+            else if (strikes[i].age_s < 300)  {
+                color = RGB565(255, 140,   0);
+                myage=1;
+            }
+            else {
+                color = RGB565(220,  40,  40);
+                myage=0;
+            }
+            if (ageloop == myage)
+                drawBolt ((int16_t)s.x, (int16_t)s.y, color);
+        }
+    }
 }

--- a/ESPHamClock/lightning.cpp
+++ b/ESPHamClock/lightning.cpp
@@ -464,25 +464,37 @@ void drawLightningOnMap (void)
     if (n_strikes == 0)
         return;
 
-    for (int i = 0; i < n_strikes; i++) {
+    for (int ageloop = 0; ageloop < 3; ageloop++) {  // age in loop goes from oldest 0 to newest 2
+		for (int i = 0; i < n_strikes; i++) {
 
-        SCoord s;
-        ll2sRaw (strikes[i].lat * (M_PIF / 180.0F),
-                 strikes[i].lng * (M_PIF / 180.0F),
-                 s, 8);
+			SCoord s;
+			ll2sRaw (strikes[i].lat * (M_PIF / 180.0F),
+					strikes[i].lng * (M_PIF / 180.0F),
+					s, 8);
 
-        if (s.x == 0 && s.y == 0)
-            continue;
+			if (s.x == 0 && s.y == 0)
+				continue;
 
-        // Don't draw over the RSS banner
-        if (overRSS (raw2appSCoord (s)))
-            continue;
+			// Don't draw over the RSS banner
+			if (overRSS (raw2appSCoord (s)))
+				continue;
 
-        uint16_t color;
-        if      (strikes[i].age_s < 120)  color = RGB565(255, 220,   0);
-        else if (strikes[i].age_s < 300)  color = RGB565(255, 140,   0);
-        else                              color = RGB565(220,  40,  40);
-
-        drawBolt ((int16_t)s.x, (int16_t)s.y, color);
-    }
+			int myage;
+			uint16_t color;
+			if      (strikes[i].age_s < 120) {
+				color = RGB565(255, 220,   0);
+				myage=2;
+			}
+			else if (strikes[i].age_s < 300)  {
+				color = RGB565(255, 140,   0);
+				myage=1;
+			}
+			else {
+				color = RGB565(220,  40,  40);
+				myage=0;
+			}
+			if (ageloop == myage)
+				drawBolt ((int16_t)s.x, (int16_t)s.y, color);
+		}
+	}
 }


### PR DESCRIPTION
added loop around adding bolts to process oldest, old, new

we want most recentent drawn last so that they will be on top

Looking at data from backend, data is not sorted old to new

Here is the tail of a query where you can see that age is not always decreasing

36.4521,-99.7319,116
33.7280,-92.7072,94
33.9540,-92.7557,93
33.7364,-92.7210,**94**
35.1672,-97.9756,92
33.9540,-92.7558,93
35.1671,-97.9753,92
34.1003,-92.8181,60
34.0770,-92.8184,60
34.0090,-92.8123,60
34.0251,-92.7491,60
34.0396,-92.8721,60
36.2794,-100.4611,54
33.8030,-92.7502,49
33.8047,-92.7443,49
35.3740,-97.4956,44
35.4742,-97.5537,44
35.4403,-97.5885,44
35.4531,-97.5585,44
35.3980,-97.5109,44
35.7159,-97.5536,42
35.7532,-97.4935,42
35.7172,-97.5081,42
35.4344,-97.5725,**44**
35.4853,-97.5353,44
35.4433,-97.5707,44
35.4382,-97.5934,44
35.4607,-97.5930,44
35.4562,-97.5468,44
35.4782,-97.5426,44
33.0463,-93.3472,40
35.5385,-97.5283,**44**
33.0279,-93.2875,40
32.9971,-93.3622,40
33.0450,-93.3452,39
33.0597,-93.3487,39
33.0971,-93.3448,39
35.4620,-97.5718,**44**
33.0597,-93.3487,39
33.2260,-93.2770,39
35.4459,-97.5170,**44**
35.5737,-97.4340,43
35.7160,-97.5536,42
35.7523,-97.4794,42
35.7172,-97.5081,42
33.8010,-92.7640,37
33.0219,-93.3244,**40**
33.0971,-93.3338,40
33.1003,-93.3486,40
33.0767,-93.3470,40
32.9744,-93.3226,40
33.1078,-93.3377,40
33.0228,-93.3290,39
33.1129,-93.3424,39
33.1342,-93.3310,39
33.1065,-93.3420,39
33.0585,-93.3494,**40**
33.0597,-93.3487,39
33.7997,-92.7611,37
34.7189,-96.8007,34
34.6128,-96.7601,34
34.6968,-96.8023,34
35.2254,-97.3298,28
35.3085,-97.3376,28
35.1842,-97.3455,28
33.7185,-92.7459,27
33.7703,-92.7250,27
35.2817,-97.3378,27
35.3120,-97.3602,27
35.3338,-97.3449,27