### PR TITLE
gitignore should track compiler output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 eeprom
 hc.settings
 tmp/
+
+# C stuff
+*.o
+*.a
+*.d


### PR DESCRIPTION
Seriously: change one tiny thing, compile once, and the worktree explodes into well over a hundred untracked files..

```bash
yo3gnd@dev:~/hamclock/ESPHamClock$ git status | wc -l
134
```