### PR TITLE
Smaller lightning icons on 800x480

### DIFF
--- a/ESPHamClock/ArduinoLib/Adafruit_RA8875.cpp
+++ b/ESPHamClock/ArduinoLib/Adafruit_RA8875.cpp
@@ -40,8 +40,6 @@
 
 #include "Adafruit_RA8875.h"
 
-extern uint8_t lightning_on;
-
 
 #ifdef _USE_FB0
 
@@ -1716,12 +1714,12 @@ float dlatr, float dlngr, float dlatd, float dlngd, float fract_day)
                 int ey = (int)((90-lat)*EARTH_BIG_H/180 + EARTH_BIG_H + 0.5F);
                 ex = (ex + EARTH_BIG_W) % EARTH_BIG_W;
                 ey = (ey + EARTH_BIG_H) % EARTH_BIG_H;
-			uint16_t c16; 
-			if (fract_day == 0) {
-			    c16 = EPIXEL(NEARTH_BIG,ey,ex);
-			} else if (fract_day == 1) {
-			    c16 = EPIXEL(DEARTH_BIG,ey,ex);
-			} else {
+		uint16_t c16; 
+		if (fract_day == 0) {
+		    c16 = EPIXEL(NEARTH_BIG,ey,ex);
+		} else if (fract_day == 1) {
+		    c16 = EPIXEL(DEARTH_BIG,ey,ex);
+		} else {
 		    // blend from day to night
 		    uint16_t day_pix = EPIXEL(DEARTH_BIG,ey,ex);
 		    uint16_t night_pix = EPIXEL(NEARTH_BIG,ey,ex);
@@ -1734,38 +1732,13 @@ float dlatr, float dlngr, float dlatd, float dlngd, float fract_day)
 		    float fract_night = 1 - fract_day;
 		    uint8_t twi_r = (fract_day*day_r + fract_night*night_r);
 		    uint8_t twi_g = (fract_day*day_g + fract_night*night_g);
-			    uint8_t twi_b = (fract_day*day_b + fract_night*night_b);
-			    c16 = RGB565 (twi_r, twi_g, twi_b);
-			}
-
-                        if (lightning_on) {
-                            /*
-                             * reduce brightness
-                             *
-                             * uint8_t r = (uint8_t)((2U * RGB565_R(c16)) / 3U);
-                             * uint8_t g = (uint8_t)((2U * RGB565_G(c16)) / 3U);
-                             * uint8_t b = (uint8_t)((2U * RGB565_B(c16)) / 3U);
-                             * c16 = RGB565 (r, g, b);
-                             */
-
-                            // Desaturate by 66% instead: keep 34% of the original chroma.
-                            uint8_t r = RGB565_R(c16);
-                            uint8_t g = RGB565_G(c16);
-                            uint8_t b = RGB565_B(c16);
-                            //uint8_t gray = (uint8_t)((77U*r + 150U*g + 29U*b) / 256U);
-                            uint8_t gray = (218*r + 732*g + 74*b + 512) >> 10;
-                            r = (uint8_t)((66U*r + 34U*gray) / 100U);
-                            g = (uint8_t)((66U*g + 34U*gray) / 100U);
-                            b = (uint8_t)((66U*b + 34U*gray) / 100U);
-                            r = (uint8_t)((5 * r) / 6);
-                            g = (uint8_t)((5 * g) / 6);
-                            b = (uint8_t)((5 * b) / 6);
-                            c16 = RGB565 (r, g, b);
-                        }
-			*frow++ = RGB16TOFBPIX(c16);
-		    }
+		    uint8_t twi_b = (fract_day*day_b + fract_night*night_b);
+		    c16 = RGB565 (twi_r, twi_g, twi_b);
 		}
+		*frow++ = RGB16TOFBPIX(c16);
+	    }
 	}
+}
 
 void Adafruit_RA8875::plotChar (char ch)
 {

--- a/ESPHamClock/ArduinoLib/Adafruit_RA8875.cpp
+++ b/ESPHamClock/ArduinoLib/Adafruit_RA8875.cpp
@@ -40,6 +40,8 @@
 
 #include "Adafruit_RA8875.h"
 
+extern uint8_t lightning_on;
+
 
 #ifdef _USE_FB0
 
@@ -1714,12 +1716,12 @@ float dlatr, float dlngr, float dlatd, float dlngd, float fract_day)
                 int ey = (int)((90-lat)*EARTH_BIG_H/180 + EARTH_BIG_H + 0.5F);
                 ex = (ex + EARTH_BIG_W) % EARTH_BIG_W;
                 ey = (ey + EARTH_BIG_H) % EARTH_BIG_H;
-		uint16_t c16; 
-		if (fract_day == 0) {
-		    c16 = EPIXEL(NEARTH_BIG,ey,ex);
-		} else if (fract_day == 1) {
-		    c16 = EPIXEL(DEARTH_BIG,ey,ex);
-		} else {
+			uint16_t c16; 
+			if (fract_day == 0) {
+			    c16 = EPIXEL(NEARTH_BIG,ey,ex);
+			} else if (fract_day == 1) {
+			    c16 = EPIXEL(DEARTH_BIG,ey,ex);
+			} else {
 		    // blend from day to night
 		    uint16_t day_pix = EPIXEL(DEARTH_BIG,ey,ex);
 		    uint16_t night_pix = EPIXEL(NEARTH_BIG,ey,ex);
@@ -1732,13 +1734,38 @@ float dlatr, float dlngr, float dlatd, float dlngd, float fract_day)
 		    float fract_night = 1 - fract_day;
 		    uint8_t twi_r = (fract_day*day_r + fract_night*night_r);
 		    uint8_t twi_g = (fract_day*day_g + fract_night*night_g);
-		    uint8_t twi_b = (fract_day*day_b + fract_night*night_b);
-		    c16 = RGB565 (twi_r, twi_g, twi_b);
+			    uint8_t twi_b = (fract_day*day_b + fract_night*night_b);
+			    c16 = RGB565 (twi_r, twi_g, twi_b);
+			}
+
+                        if (lightning_on) {
+                            /*
+                             * reduce brightness
+                             *
+                             * uint8_t r = (uint8_t)((2U * RGB565_R(c16)) / 3U);
+                             * uint8_t g = (uint8_t)((2U * RGB565_G(c16)) / 3U);
+                             * uint8_t b = (uint8_t)((2U * RGB565_B(c16)) / 3U);
+                             * c16 = RGB565 (r, g, b);
+                             */
+
+                            // Desaturate by 66% instead: keep 34% of the original chroma.
+                            uint8_t r = RGB565_R(c16);
+                            uint8_t g = RGB565_G(c16);
+                            uint8_t b = RGB565_B(c16);
+                            //uint8_t gray = (uint8_t)((77U*r + 150U*g + 29U*b) / 256U);
+                            uint8_t gray = (218*r + 732*g + 74*b + 512) >> 10;
+                            r = (uint8_t)((66U*r + 34U*gray) / 100U);
+                            g = (uint8_t)((66U*g + 34U*gray) / 100U);
+                            b = (uint8_t)((66U*b + 34U*gray) / 100U);
+                            r = (uint8_t)((5 * r) / 6);
+                            g = (uint8_t)((5 * g) / 6);
+                            b = (uint8_t)((5 * b) / 6);
+                            c16 = RGB565 (r, g, b);
+                        }
+			*frow++ = RGB16TOFBPIX(c16);
+		    }
 		}
-		*frow++ = RGB16TOFBPIX(c16);
-	    }
 	}
-}
 
 void Adafruit_RA8875::plotChar (char ch)
 {

--- a/ESPHamClock/ESPHamClock.cpp
+++ b/ESPHamClock/ESPHamClock.cpp
@@ -1710,6 +1710,7 @@ void drawAllSymbols()
     drawFarthestPSKSpots();
     drawLightningOnMap();
     drawSanta ();
+    notifyLightningBlockedMap();
 
     updateClocks(false);
 }

--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -2367,6 +2367,7 @@ extern void initLightning (void);
 extern void resetLightning (void);
 extern void updateLightning (void);
 extern void drawLightningOnMap (void);
+extern void notifyLightningBlockedMap (void);
 extern void doLightningTouch (void);
 extern uint8_t  ltg_worldwide;          // 1=worldwide, 0=radius mode
 extern uint16_t ltg_radius_km;          // search radius when not worldwide

--- a/ESPHamClock/lightning.cpp
+++ b/ESPHamClock/lightning.cpp
@@ -74,6 +74,33 @@ static void drawBolt (int16_t cx, int16_t cy, uint16_t color)
     uint16_t my = (uint16_t)(tft.SCALESZ * map_b.y);
     uint16_t mw = (uint16_t)(tft.SCALESZ * map_b.w);
     uint16_t mh = (uint16_t)(tft.SCALESZ * map_b.h);
+
+    // 800x480: smol lightning
+    //   ..x
+    //   .x.
+    //   xxx
+    //   .x.
+    //   x..
+    if (tft.SCALESZ == 1) {
+        if (cx-1 < (int16_t)mx || cx+1 >= (int16_t)(mx+mw) ||
+            cy-2 < (int16_t)my || cy+2 >= (int16_t)(my+mh))
+            return;
+
+        //tft.drawPixelRaw (cx+1, cy-2, color);
+        //tft.drawPixelRaw (cx,   cy-1, color);
+        //tft.drawPixelRaw (cx-1, cy,   color);
+        tft.drawPixelRaw (cx,   cy,   color);
+        //tft.drawPixelRaw (cx,   cy,   RA8875_WHITE);
+        //tft.drawPixelRaw (cx+1, cy,   color);
+        //tft.drawPixelRaw (cx,   cy+1, color);
+        //tft.drawPixelRaw (cx-1, cy+2, color);
+        tft.drawPixelRaw (cx+1,   cy,   color);
+        tft.drawPixelRaw (cx-1,   cy,   color);
+        tft.drawPixelRaw (cx,   cy-1,   color);
+        tft.drawPixelRaw (cx,   cy+1,   color);
+        return;
+    }
+
     if (cx-4 < (int16_t)mx || cx+4 >= (int16_t)(mx+mw) ||
         cy-6 < (int16_t)my || cy+6 >= (int16_t)(my+mh))
         return;
@@ -185,7 +212,8 @@ static bool fetchLightning (void)
 out:
     client.stop();
     if (!ok)
-        n_strikes = 0;   // always reset on failure so panel shows clean zero
+        n_strikes = 0;
+    scheduleFreshMap();
     return ok;
 }
 
@@ -314,6 +342,7 @@ void resetLightning (void)
 {
     n_strikes  = 0;
     next_fetch = 0;
+    scheduleFreshMap();
 }
 
 /* Restore NV state at startup.

--- a/ESPHamClock/lightning.cpp
+++ b/ESPHamClock/lightning.cpp
@@ -68,34 +68,23 @@ uint16_t ltg_radius_km;     // extern; search radius in km when not worldwide
 
 static void drawBolt (int16_t cx, int16_t cy, uint16_t color)
 {
-    // Guard: bolt extends 6px vertically and 4px horizontally from centre.
-    // Use raw map bounds to ensure every pixel lands on screen.
     uint16_t mx = (uint16_t)(tft.SCALESZ * map_b.x);
     uint16_t my = (uint16_t)(tft.SCALESZ * map_b.y);
     uint16_t mw = (uint16_t)(tft.SCALESZ * map_b.w);
     uint16_t mh = (uint16_t)(tft.SCALESZ * map_b.h);
 
-    if (tft.SCALESZ == 1) {
-        if (cx-1 < (int16_t)mx || cx+1 >= (int16_t)(mx+mw) ||
-            cy-2 < (int16_t)my || cy+2 >= (int16_t)(my+mh))
-            return;
+    // arm length scales with build size and current zoom level
+    int16_t arm = (int16_t)(tft.SCALESZ * pan_zoom.zoom);
+    if (arm < 1)
+        arm = 1;
 
-        tft.drawPixelRaw (cx,   cy,   color);
-        tft.drawPixelRaw (cx+1, cy,   color);
-        tft.drawPixelRaw (cx-1, cy,   color);
-        tft.drawPixelRaw (cx,   cy-1, color);
-        tft.drawPixelRaw (cx,   cy+1, color);
-        return;
-    }
-
-    if (cx-4 < (int16_t)mx || cx+4 >= (int16_t)(mx+mw) ||
-        cy-6 < (int16_t)my || cy+6 >= (int16_t)(my+mh))
+    if (cx - arm < (int16_t)mx || cx + arm >= (int16_t)(mx + mw) ||
+        cy - arm < (int16_t)my || cy + arm >= (int16_t)(my + mh))
         return;
 
-    tft.drawLineRaw (cx+2, cy-6,  cx-2, cy-1,  2, color);
-    tft.drawLineRaw (cx-4, cy,    cx+4, cy,     2, color);
-    tft.drawLineRaw (cx+2, cy+1,  cx-2, cy+6,  2, color);
-    tft.drawPixelRaw (cx, cy, RA8875_WHITE);
+    // horizontal and vertical arms
+    tft.drawLineRaw (cx - arm, cy,       cx + arm, cy,       1, color);
+    tft.drawLineRaw (cx,       cy - arm, cx,       cy + arm, 1, color);
 }
 
 // ---- response parsing ----------------------------------------------------

--- a/ESPHamClock/lightning.cpp
+++ b/ESPHamClock/lightning.cpp
@@ -75,29 +75,16 @@ static void drawBolt (int16_t cx, int16_t cy, uint16_t color)
     uint16_t mw = (uint16_t)(tft.SCALESZ * map_b.w);
     uint16_t mh = (uint16_t)(tft.SCALESZ * map_b.h);
 
-    // 800x480: smol lightning
-    //   ..x
-    //   .x.
-    //   xxx
-    //   .x.
-    //   x..
     if (tft.SCALESZ == 1) {
         if (cx-1 < (int16_t)mx || cx+1 >= (int16_t)(mx+mw) ||
             cy-2 < (int16_t)my || cy+2 >= (int16_t)(my+mh))
             return;
 
-        //tft.drawPixelRaw (cx+1, cy-2, color);
-        //tft.drawPixelRaw (cx,   cy-1, color);
-        //tft.drawPixelRaw (cx-1, cy,   color);
         tft.drawPixelRaw (cx,   cy,   color);
-        //tft.drawPixelRaw (cx,   cy,   RA8875_WHITE);
-        //tft.drawPixelRaw (cx+1, cy,   color);
-        //tft.drawPixelRaw (cx,   cy+1, color);
-        //tft.drawPixelRaw (cx-1, cy+2, color);
-        tft.drawPixelRaw (cx+1,   cy,   color);
-        tft.drawPixelRaw (cx-1,   cy,   color);
-        tft.drawPixelRaw (cx,   cy-1,   color);
-        tft.drawPixelRaw (cx,   cy+1,   color);
+        tft.drawPixelRaw (cx+1, cy,   color);
+        tft.drawPixelRaw (cx-1, cy,   color);
+        tft.drawPixelRaw (cx,   cy-1, color);
+        tft.drawPixelRaw (cx,   cy+1, color);
         return;
     }
 
@@ -345,6 +332,67 @@ void resetLightning (void)
     scheduleFreshMap();
 }
 
+static bool lightningBlockedMap (void)
+{
+    switch (core_map) {
+    case CM_PMTOA:
+    case CM_PMREL:
+    case CM_MUF_V:
+    case CM_MUF_RT:
+    case CM_DRAP:
+    case CM_AURORA:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static void showLightningBlockedMapMsg (void)
+{
+    static const char msg[] = "Lightning not available on this map";
+    FontWeight fw;
+    FontSize fs;
+    uint16_t msg_w;
+    uint16_t box_w;
+    const uint16_t box_h = 30;
+    uint8_t *bs = NULL;
+
+    getFontStyle (&fw, &fs);
+    selectFontStyle (LIGHT_FONT, FAST_FONT);
+    msg_w = getTextWidth (msg);
+    box_w = msg_w + 20;
+    if (box_w > map_b.w - 20)
+        box_w = map_b.w - 20;
+
+    SBox box = {
+        (uint16_t) (map_b.x + (map_b.w - box_w)/2),
+        (uint16_t) (map_b.y + map_b.h/10),
+        box_w,
+        box_h
+    };
+    if (!tft.getBackingStore (bs, box.x, box.y, box.w, box.h)) {
+        selectFontStyle (fw, fs);
+        return;
+    }
+
+    fillSBox (box, RA8875_BLACK);
+    drawSBox (box, RA8875_WHITE);
+    tft.setCursor (box.x + (box.w - msg_w)/2, box.y + box.h/3);
+    tft.setTextColor (RA8875_WHITE);
+    tft.print (msg);
+    tft.drawPR();
+    wdDelay (2000);
+
+    if (!tft.setBackingStore (bs, box.x, box.y, box.w, box.h)) {
+        if (bs)
+            free (bs);
+        selectFontStyle (fw, fs);
+        return;
+    }
+    tft.drawPR();
+    selectFontStyle (fw, fs);
+}
+
 /* Restore NV state at startup.
  * N.B. follows the HamClock pattern of writing the default if no cookie found.
  */
@@ -481,6 +529,9 @@ void drawLightningOnMap (void)
     if (!lightning_on)
         return;
 
+    if (lightningBlockedMap())
+        return;
+
     // Rings and attribution  - Mercator only, always on when overlay enabled
     if (map_proj == MAPP_MERCATOR) {
         drawLightningRings();
@@ -521,4 +572,17 @@ void drawLightningOnMap (void)
 
         drawBolt ((int16_t)s.x, (int16_t)s.y, color);
     }
+}
+
+void notifyLightningBlockedMap (void)
+{
+    static bool was_blocked;
+    static bool was_on;
+    bool blocked = lightning_on && lightningBlockedMap();
+
+    if (blocked && (!was_blocked || !was_on))
+        showLightningBlockedMapMsg();
+
+    was_blocked = blocked;
+    was_on = lightning_on;
 }


### PR DESCRIPTION
I have trimmed this back to the narrow fix discussed in #119. On 800x480, lightning now uses the small crosshair only; the map itself is no longer dimmed or desaturated. On TOA/REL, MUF-VCAP/MUF-RT, DRAP, and Aurora, the lightning overlay is simply suppressed, with a brief “Lightning not available on this map” notice instead. That feels like the cleaner trade: fix legibility where it was poor, and avoid meddling with maps whose colours are already doing real work.