### PR TITLE
Allow non-root install

### DIFF
--- a/ESPHamClock/Makefile
+++ b/ESPHamClock/Makefile
@@ -301,7 +301,12 @@ install:
 	if ! [ -x $$SOURCE ] ; then \
 		echo 'make something first' ; \
 		make help ; \
-	elif [ `id -un` != 'root' ] && [ -w $$DIR ] ; then \
+	elif [ `id -un` != 'root' ] && \
+	     ( D="$$DIR"; \
+	       while [ ! -d "$$D" ]; do \
+	           D=`dirname "$$D"`; \
+	       done ; \
+	       [ -w "$$D" ] ) ; then \
 		mkdir -p $$DIR \
 		&& mv -f $$SOURCE $$TARGET ; \
 	elif [ `id -un` != 'root' ] ; then \

--- a/ESPHamClock/Makefile
+++ b/ESPHamClock/Makefile
@@ -294,14 +294,16 @@ hamclock-fb0-3200x1920: $(OBJS) hclibs
 
 
 
-# /usr/local/bin seems right although Alpine linux does not have it even though it is in the default PATH
 install:
 	@SOURCE=hamclock-*0x*0 ; \
-	DIR=/usr/local/bin ; \
+	DIR=$${DIR:-/usr/local/bin} ; \
 	TARGET=$$DIR/hamclock ; \
 	if ! [ -x $$SOURCE ] ; then \
 		echo 'make something first' ; \
 		make help ; \
+	elif [ `id -un` != 'root' ] && [ -w $$DIR ] ; then \
+		mkdir -p $$DIR \
+		&& mv -f $$SOURCE $$TARGET ; \
 	elif [ `id -un` != 'root' ] ; then \
 		echo please run with sudo ; \
 	else \


### PR DESCRIPTION
This supports setting DIR= environment for the target install and not doing root stuff if not needed. Helps with better hardening.