### PR TITLE
Draws sats on top

### DIFF
--- a/ESPHamClock/ESPHamClock.cpp
+++ b/ESPHamClock/ESPHamClock.cpp
@@ -1714,6 +1714,7 @@ void drawAllSymbols()
     drawDXMarker(false);
     drawFarthestPSKSpots();
     drawLightningOnMap();
+    drawSatPathAndFoot();
     drawSanta ();
     drawEnterprise ();
 


### PR DESCRIPTION
The sat tracks were being drawn under lightning, spot paths and possibly other things. This puts sats at the top.