### PR TITLE
Starting the next beta series

### DIFF
--- a/HC_RELEASE-beta.txt
+++ b/HC_RELEASE-beta.txt
@@ -1,2 +1,3 @@
 Changes with latest release:
-- no changes at this time
+- starting the new beta series
+- no changes from 4.26, yet


### PR DESCRIPTION
Getting ready for 4.27 beta. b00 is just 4.26 but marked beta so bleeding edge users can get on the track.