### PR TITLE
Ensure rounding and digits show correctly

### DIFF
--- a/ESPHamClock/dashboard-html.cpp
+++ b/ESPHamClock/dashboard-html.cpp
@@ -98,7 +98,10 @@ const char dashboard_html[] = R"HCDB(
   function renderBands(rows){
     const wanted = preferredBands.map(b => rows.find(r => r.band === b)).filter(Boolean);
     const show = wanted.length ? wanted : rows.slice(0,8);
-    $('bands').innerHTML = show.map(r => `<div class="band"><div class="bandname">${r.band}</div><div class="bar"><div class="fill" style="width:${Math.max(0,Math.min(100,r.now))}%"></div></div><div class="pct">${r.now}%</div></div>`).join('') || '<span class="sub">No VOACAP matrix</span>';
+    $('bands').innerHTML = show.map(r => {
+      const p = Math.max(0, Math.min(100, Math.round(r.now) || 0));
+      return `<div class="band"><div class="bandname">${r.band}</div><div class="bar"><div class="fill" style="width:${p}%"></div></div><div class="pct">${p}%</div></div>`;
+    }).join('') || '<span class="sub">No VOACAP matrix</span>';
   }
   function parseSpots(txt, limit){
     const rows=[];

--- a/ESPHamClock/webserver.cpp
+++ b/ESPHamClock/webserver.cpp
@@ -1709,7 +1709,7 @@ static bool getWiFiVOACAP (WiFiClient &client, char *line, size_t line_len)
     int hr_now = bc_utc_tl ? utc_hour_now : de_hour_now;
 
     // display matrix -- rotated with same layout as plotBandConditions()
-    char buf[100];
+    char buf[128];
     int buf_l = 0;
     for (int p_row = 0; p_row < BMTRX_COLS; p_row++) {  // print 1 row for each matrix column
         int m_col = BMTRX_COLS - 1 - p_row;             // convert to bm col with 10 (last col) on top
@@ -1726,7 +1726,7 @@ static bool getWiFiVOACAP (WiFiClient &client, char *line, size_t line_len)
             // bc_matrix is a matrix of 24 rows of UTC 0 .. 23, 8 columns of bands 80-40-30-20-17-15-12-10.
             uint8_t rel = bc_matrix.m[m_row][m_col];
 
-            buf_l += snprintf (buf+buf_l, sizeof(buf)-buf_l, "%3d", rel);
+            buf_l += snprintf (buf+buf_l, sizeof(buf)-buf_l, "%4d", rel);
         }
 
         // finish with band freq
@@ -1743,9 +1743,9 @@ static bool getWiFiVOACAP (WiFiClient &client, char *line, size_t line_len)
     for (int p_col = 0; p_col < BMTRX_ROWS; p_col++) {
         int hr = (hr_now + p_col) % 24;
         if ((hr%4) != 0)
-            buf_l += snprintf (buf+buf_l, sizeof(buf)-buf_l, "   ");
+            buf_l += snprintf (buf+buf_l, sizeof(buf)-buf_l, "    ");
         else
-            buf_l += snprintf (buf+buf_l, sizeof(buf)-buf_l, "%3d", hr);
+            buf_l += snprintf (buf+buf_l, sizeof(buf)-buf_l, "%4d", hr);
     }
     client.println (buf);
 


### PR DESCRIPTION
In cases where the numbers are boarderline, fix the display to properly round values.

What was show in the issue I can't recreate. It looks more like a divide by zero issue since the value was on the order of e+58. The fix is likely the max/min test.