### PR TITLE
Update beta release notes

### DIFF
--- a/HC_RELEASE-beta.txt
+++ b/HC_RELEASE-beta.txt
@@ -1,2 +1,5 @@
 Changes with latest release:
-- netlogger panel
+- new netlogger panel
+- mbox icon disappears sometimes
+- fix #189 tropics in zoom
+- fix #193 band value display

--- a/HC_RELEASE-stable.txt
+++ b/HC_RELEASE-stable.txt
@@ -1,5 +1,5 @@
 Changes with latest release:
-- mobile dashboard on 8080:/dashboard.html
+- mobile dashboard on :8080/dashboard.html
 - update dxcluster connection retry
 - center clicked on zoom map
 - lightning uses config units


### PR DESCRIPTION
New changes for the next beta.

Also a typo in the last stable release notes. This doesn't get picked up in the tag but grabbing it in case we do a point release.