### PR TITLE
Set voacap artifact timeouts to 15s

### DIFF
--- a/ESPHamClock/ArduinoLib/WiFiClient.h
+++ b/ESPHamClock/ArduinoLib/WiFiClient.h
@@ -62,6 +62,7 @@ public:
     void println (float f, int n);
     void flush(void){};
     IPAddress remoteIP(void);
+    void setTimeout(uint16_t ms) { read_pending_ms = ms; }
 
 private:
 

--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -1114,8 +1114,9 @@ extern void doNCDXFBoxTouch (TouchType tt, const SCoord &s);
 // special cleanCache ages
 #define CACHE_FOREVER 0                         // never remove matching files
 #define CACHE_NONE    1                         // remove all files older than 1 second
+#define VOACAP_TIMEOUT_MS 15000                 // timeout for VOACAP and band conditions endpoints
 
-extern FILE *openCachedFile (const char *fn, const char *url, int max_age, int min_size);
+extern FILE *openCachedFile (const char *fn, const char *url, int max_age, int min_size, int to_ms = 0);
 extern bool cleanCache (const char *contains, int max_age);
 
 

--- a/ESPHamClock/cachefile.cpp
+++ b/ESPHamClock/cachefile.cpp
@@ -56,7 +56,7 @@ static bool fileAgeOk (const char *path, int max_age)
 /* open the given local file or download fresh if too old or too small.
  * if download fails retain fn as long as it's large enough, tolerating too old.
  */
-FILE *openCachedFile (const char *fn, const char *url, int max_age, int min_size)
+FILE *openCachedFile (const char *fn, const char *url, int max_age, int min_size, int to_ms)
 {
     // try local first
     char fn_path[1000];
@@ -77,6 +77,8 @@ FILE *openCachedFile (const char *fn, const char *url, int max_age, int min_size
 
     // download
     WiFiClient cache_client;
+    if (to_ms > 0)
+        cache_client.setTimeout(to_ms);
     Serial.println (url);
     if (cache_client.connect(backend_host, backend_port)) {
 

--- a/ESPHamClock/mapmanage.cpp
+++ b/ESPHamClock/mapmanage.cpp
@@ -346,6 +346,7 @@ long max_age)
             noteVOACAPAttempt(now);
 
             WiFiClient client;
+            client.setTimeout(VOACAP_TIMEOUT_MS);
             if (client.connect(backend_host, backend_port)) {
                 mapMsg (0, "%s", msg);
                 char url[2*QBUFLEN];

--- a/ESPHamClock/wifi.cpp
+++ b/ESPHamClock/wifi.cpp
@@ -877,7 +877,7 @@ static bool retrieveBandConditions (char *config)
     snprintf (cache_fn, sizeof(cache_fn), "bc-%010u.txt", stringHash(query)); // N.B. see cleanCache() above
 
     // open cache or get fresh
-    FILE *fp = openCachedFile (cache_fn, query, 12*3600L, 100);
+    FILE *fp = openCachedFile (cache_fn, query, 12*3600L, 100, VOACAP_TIMEOUT_MS);
     if (fp) {
 
         char buf[100];


### PR DESCRIPTION
The longest backend process is the voacap endpoints. If the backend gets slow, for example when loaded, a longer timeout would really be nice, especially for the backend which wasted all that time to have the result ignored. So this commit bumps the client timeout to 15s for voacap endpoints.