### PR TITLE
Allow mice with three buttons to use all three and not have the third…

### DIFF
--- a/ESPHamClock/ArduinoLib/Adafruit_RA8875.cpp
+++ b/ESPHamClock/ArduinoLib/Adafruit_RA8875.cpp
@@ -2115,12 +2115,15 @@ void Adafruit_RA8875::saveWinGeom(void)
 // _USE_X11
 int Adafruit_RA8875::decodeMouseButton (XEvent event)
 {
-        // button1+mods or button2 coded as Button2, all else as Button1.
-        // N.B. Mac's report plane Button2 with Button1+Option
+        // plain Button1 is a normal (primary) click; everything else -- a genuine right-click
+        // (Button3), a middle-click (Button2), or Button1 with a modifier (for one-button
+        // trackpads, eg Mac's Option+click reports Button2) -- is treated as the secondary/
+        // "alternate" click used eg to right-click-spot a row.
         bool mods = (event.xbutton.state & (Mod1Mask|ControlMask)) != 0;
-        return ((event.xbutton.button == Button1 && mods) || (event.xbutton.button == Button2)
-                        ? Button2 : Button1
-        );
+        bool alt_click = (event.xbutton.button == Button1 && mods)
+                          || event.xbutton.button == Button2
+                          || event.xbutton.button == Button3;
+        return (alt_click ? Button2 : Button1);
 }
 
 /* thread that runs forever reacting to X11 events and painting fb_canvas whenever it changes

--- a/ESPHamClock/hamsat.cpp
+++ b/ESPHamClock/hamsat.cpp
@@ -492,8 +492,11 @@ static void drawHamsatVisAlerts (const SBox &box)
             else
                 // wide pane (1/2/3): same issue as above -- satnames like AO-123 fill the whole
                 // %-6.6s field with no trailing pad, so force a literal 1-char gap before the
-                // countdown instead of relying on padding.
-                snprintf (line, sizeof(line), "%-7.7s%-6.6s %s", a.callsign, a.satname, cd);
+                // countdown instead of relying on padding. callsign is trimmed to 6 (not 7) so a
+                // literal 1-char gap can likewise be forced between it and satname -- otherwise a
+                // 7+ char callsign (eg a portable suffix like LA/DF2ET/P) fills %-7.7s with no
+                // trailing pad and runs straight into the satname (eg "LA/DF2EFO-29").
+                snprintf (line, sizeof(line), "%-6.6s %-6.6s %s", a.callsign, a.satname, cd);
             #define SOON_SECS       (15*60)            // "starting soon" threshold, seconds
             uint16_t line_color;
             if (a.aos_at && a.aos_at <= now && (a.los_at == 0 || a.los_at > now))


### PR DESCRIPTION
… button be translated as button 1 (left click) this is in support of right click on the ONTA pane and future use