### PR TITLE
Suppress irrelevant warnings

### DIFF
--- a/ESPHamClock/Makefile
+++ b/ESPHamClock/Makefile
@@ -70,7 +70,7 @@ ifeq ($(shell uname -s), NetBSD)
 endif
 
 # Linux needs libgpiod
-ifeq ($(shell find /usr/lib -name libgpiod.a | wc -l), 1)
+ifeq ($(shell find /usr/lib -name libgpiod.a 2>/dev/null | wc -l), 1)
     LIBS += -lgpiod
 endif
 


### PR DESCRIPTION
When compiling or cleaning, the line that looks for libgiod.a transverses folders that non-root can't access. Suppress the warnings. Especially with "make clean". It looks scary. =8-|