### PR TITLE
Allow status line to update while msg popup open

### DIFF
--- a/ESPHamClock/ESPHamClock.cpp
+++ b/ESPHamClock/ESPHamClock.cpp
@@ -686,9 +686,7 @@ void loop()
         drawMoreEarth();
 
         // other goodies
-        drawUptime(false);
-        drawRotatingMessage();
-        drawVersion(false);
+        updateCallsignStatus(false);
         followBrightness();
         checkOnAirPin();
         readBME280();
@@ -1604,6 +1602,21 @@ static void drawUptime(bool force)
         tft.printf ("%2dd %2dh", days, hrs);
         prev_h = hrs;
     }
+}
+
+/* update gray status items under callsign (uptime, rotating message, version)
+ */
+void updateCallsignStatus (bool force)
+{
+    FontWeight fw;
+    FontSize fs;
+    getFontStyle (&fw, &fs);
+
+    drawUptime (force);
+    drawRotatingMessage ();
+    drawVersion (force);
+
+    selectFontStyle (fw, fs);
 }
 
 /* given an SCoord in raw coords, return one in app coords

--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -820,6 +820,7 @@ extern void newDX (LatLong &ll, const char grid[MAID_CHARLEN], const char *overr
 extern void drawDXPath(void);
 extern bool screenIsLocked(void);
 extern time_t getUptime (uint16_t *days, uint8_t *hrs, uint8_t *mins, uint8_t *secs);
+extern void updateCallsignStatus (bool force);
 extern void eraseScreen(void);
 extern void setMapTagBox (const char *tag, const SCoord &c, uint16_t r, SBox &box);
 extern void drawMapTag (const char *tag, const SBox &box, uint16_t txt_color = RA8875_WHITE,

--- a/ESPHamClock/clocks.cpp
+++ b/ESPHamClock/clocks.cpp
@@ -1081,6 +1081,9 @@ void updateClocks(bool all)
     if (hide_clocks)
         return;
 
+    // update status items under callsign (uptime, rotating message, version)
+    updateCallsignStatus (all);
+
     // get user's UTC time now, get out fast if still same second
     time_t t_wo = nowWO();
     if ((t_wo%60) == prev_sc && !all)


### PR DESCRIPTION
When the message popup is open, the clock updates but the rotating message does not. That seems weird. Let that message update. We can see it afterall.