### PR TITLE
planets.cpp: fix popup dismissal erasing map overlay via async sweep …

### DIFF
--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -1534,6 +1534,7 @@ extern void drawSun (void);
 extern void drawMoon (void);
 extern void drawDXInfo (void);
 extern void scheduleMapRedraw (void);
+extern void redrawMapBox (const SBox &box);
 extern void mm_redraw(void);
 extern bool mm_up (void);
 extern void ll2s (const LatLong &ll, SCoord &s, uint8_t edge);

--- a/ESPHamClock/earthmap.cpp
+++ b/ESPHamClock/earthmap.cpp
@@ -55,6 +55,7 @@ uint16_t EARTH_GRIDC, EARTH_GRIDC00;            // main and highlighted
 bool mapmenu_pending;
 
 static void updateCircumstances();
+static void drawMapGrid();
 
 /* request a fresh visual sweep of the current map without reloading its source data.
  * used to clear old overlays and redraw moving symbols on demand.
@@ -66,6 +67,39 @@ void scheduleMapRedraw (void)
     moremap_active = true;
     next_redraw_ms = 0;
     moremap_generation++;
+}
+
+/* redraw just the given screen box: restore the underlying map pixels then redraw everything
+ * that might legitimately overlay them (grid, paths, planet/DX/sat markers, info box, etc).
+ *
+ * Use this -- instead of scheduleMapRedraw()/scheduleFreshMap() -- to erase a small transient
+ * popup. Those functions only (re)draw overlay symbols once, at the end of a full, multi-frame,
+ * row-by-row sweep of the entire map (see drawMoreEarth() below); if something calls them again
+ * before that sweep finishes (e.g. a user tapping open/closed a planet popup faster than a sweep
+ * completes) the sweep restarts from the top and the end-of-sweep symbol redraw keeps getting
+ * starved, which is what let old overlay data (planet dots, DX/sat markers, paths, etc) disappear,
+ * partially or completely, until a sweep was finally left undisturbed long enough to finish.
+ * This function instead does its work synchronously and immediately, with no dependency on the
+ * sweep's progress, so it can't be interrupted or starved no matter how quickly it's re-invoked.
+ */
+void redrawMapBox (const SBox &box)
+{
+    for (uint16_t y = box.y; y < box.y + box.h; y++)
+        for (uint16_t x = box.x; x < box.x + box.w; x++)
+            drawMapCoord (x, y);
+
+    if (core_map != CM_USER) {
+        drawMapGrid();
+        drawSatPathAndFoot();
+        if (waiting4DXPath())
+            drawDXPath();
+        drawPSKPaths();
+        drawAllSymbols();
+        drawSatName();
+        drawInfoBox();
+    }
+
+    tft.drawPR();
 }
 
 

--- a/ESPHamClock/planets.cpp
+++ b/ESPHamClock/planets.cpp
@@ -310,8 +310,13 @@ static void showPlanetPopup (int pid, const SCoord &s)
     };
     waitForUser (dismiss_ui);
 
-    // erase by forcing a fresh map redraw
-    scheduleFreshMap ();
+    // erase just the popup box and redraw anything that overlays it, synchronously.
+    // N.B. do NOT use scheduleFreshMap()/scheduleMapRedraw() here: those only redraw overlay
+    // symbols (planet dots, DX/sat markers, paths, etc) once, at the end of a multi-frame,
+    // row-by-row sweep of the whole map. If the user taps open/closed another planet popup
+    // before that sweep finishes, the sweep restarts from scratch and the symbol redraw never
+    // gets to run, which is what caused the overlay data to disappear (partially or completely).
+    redrawMapBox (popup_b);
 }
 
 /* check for a tap on a planet marker. return whether handled.


### PR DESCRIPTION
…race

showPlanetPopup() erased itself with scheduleFreshMap(), which restarts the full-map async row sweep from scratch. Overlay symbols are only redrawn once, at the end of that sweep, so rapid taps that restart it before completion could starve the symbol redraw indefinitely, making planet/DX/sat overlays disappear partially or entirely.

Add redrawMapBox() to erase just the popup's box synchronously, independent of the sweep, and use it in place of scheduleFreshMap().