### PR TITLE
planets.cpp: finish any in-progress map sweep before showing popup

### DIFF
--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -1517,6 +1517,7 @@ extern SCircle moon_c;
 extern uint8_t flash_crc_ok;
 
 extern void drawMoreEarth (void);
+extern void finishMapSweepNow (void);
 extern void eraseDEMarker (void);
 extern void eraseDEAPMarker (void);
 extern void drawDEMarker (bool force);

--- a/ESPHamClock/earthmap.cpp
+++ b/ESPHamClock/earthmap.cpp
@@ -57,6 +57,12 @@ bool mapmenu_pending;
 static void updateCircumstances();
 static void drawMapGrid();
 
+void finishMapSweepNow (void)
+{
+	while (moremap_active)
+		drawMoreEarth();
+}
+
 /* request a fresh visual sweep of the current map without reloading its source data.
  * used to clear old overlays and redraw moving symbols on demand.
  */

--- a/ESPHamClock/hamsat.cpp
+++ b/ESPHamClock/hamsat.cpp
@@ -401,11 +401,11 @@ static bool retrieveHamsat (void)
  * drawing
  */
 
-/* format "Hh MMm", "DdHhMMm", "9+", or "NOW" until aos, relative to now.
+/* format "Hh MMm", "DdHhMMm", "9+ days", or "NOW" until aos, relative to now.
  * once a pass is a day or more away, the day count is prefixed onto the existing "Hh MMm" form
  * (eg "5d6h58m") rather than letting hours alone run to 3+ digits ("99h58m" was ambiguous --
  * could mean 99h or actually be several days out, clamped/truncated). once beyond 9 days out,
- * collapse to "9+" rather than growing the day count past 1 digit.
+ * collapse to "9+ days" rather than growing the day count past 1 digit.
  */
 static void formatCountdown (time_t aos, time_t now, char *buf, size_t buflen)
 {
@@ -421,7 +421,7 @@ static void formatCountdown (time_t aos, time_t now, char *buf, size_t buflen)
     // value-range analysis to avoid -Wformat-truncation (same convention used in lightning.cpp)
     #define CD_CLAMP(n,mx) ((n) > (mx) ? (mx) : (n))
     if (days > 9)
-        snprintf (buf, buflen, "9+");
+        snprintf (buf, buflen, "9+ days");
     else if (days > 0)
         snprintf (buf, buflen, "%dd%dh%02dm", CD_CLAMP(days,9), CD_CLAMP(hr,23), mn);
     else if (hr > 0)

--- a/ESPHamClock/planets.cpp
+++ b/ESPHamClock/planets.cpp
@@ -237,8 +237,11 @@ void drawPlanetsOnMap (void)
         LatLong ll (pn.sub_lat, pn.sub_lng);
         SCoord sc;
         ll2s (ll, sc, PLANET_R+1);
-        if (sc.x == 0 && sc.y == 0)
-            continue;                                       // off zoomed/rotated map
+        //if (sc.x == 0 && sc.y == 0)
+        //     continue;                                       // off zoomed/rotated map
+
+	if (!overMap(sc))
+           continue;
 
         tft.fillCircle (sc.x, sc.y, PLANET_R, planet_els[i].color);
         tft.drawCircle (sc.x, sc.y, PLANET_R, RA8875_BLACK);

--- a/ESPHamClock/planets.cpp
+++ b/ESPHamClock/planets.cpp
@@ -258,6 +258,8 @@ static void showPlanetPopup (int pid, const SCoord &s)
     PlanetNow pn;
     computePlanet ((PlanetId)pid, myNow(), pn);
 
+    finishMapSweepNow();
+
     SBox popup_b;
     popup_b.w = 150;
     popup_b.h = 80;

--- a/ESPHamClock/setup.cpp
+++ b/ESPHamClock/setup.cpp
@@ -498,7 +498,7 @@ static StringPrompt string_pr[N_SPR] = {
 
     // "page 4" -- index 3
 
-    {3, { 10, R2Y(0), 190, PR_H}, {210, R2Y(0), 600, PR_H}, "hams.at key:  ", hamsat_key, NV_HAMSATKEY_LEN, 0, 0,
+    {3, { 10, R2Y(0), 140, PR_H}, {160, R2Y(0), 490, PR_H}, "hams.at key:  ", hamsat_key, NV_HAMSATKEY_LEN, 0, 0,
                 "Enter your hams.at API key for personalized satellite activation match%/visibility, "
                 "or leave blank"},
 


### PR DESCRIPTION
waitForUser() never advances the map's background row sweep, so a popup opened while a sweep happened to be mid-flight froze it there -- overlay symbols (only redrawn at end-of-sweep) stayed missing for as long as the popup was up. Add finishMapSweepNow() to drain any active sweep synchronously before drawing the popup, so nothing is left mid-flight when the modal wait begins.