### PR TITLE
Modify backend host selection logic

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -5,10 +5,10 @@ if [ -z "$HC_SIZE" ]; then
     HC_SIZE=2400x1440
 fi
 
-if [ -z "$BACKEND_HOST" -a -e /opt/hamclock/backend_host ]; then
-    BACKEND_HOST="$(grep -v '^#' /opt/hamclock/backend_host)"
-fi
-if [ -n "$BACKEND_HOST" ]; then
+OVERRIDE_BACKEND_HOST="$(grep -v '^#' /opt/hamclock/backend_host | head -n 1)"
+if [ -n "$OVERRIDE_BACKEND_HOST" ]; then
+    BACKEND_ARG="-b $OVERRIDE_BACKEND_HOST"
+elif [ -n "$BACKEND_HOST" ]; then
     BACKEND_ARG="-b $BACKEND_HOST"
 fi
 


### PR DESCRIPTION
If an optional file internal to the container has a value set, use that and override the manage-hc-docker setting. So the manage-hc-docker setting because a sort of default and modifying the container takes priority.

If neither is set then it will fall back to the setting in the source code which is currently clearskyinstitute.com, and no longer works. We can't have a preferred backend with multiple providers so we give deference to CSI's original setting and require an override.