### PR TITLE
setup: fix color editor label crowding; earthmap/borders: fix map ove…

### DIFF
--- a/ESPHamClock/borders.cpp
+++ b/ESPHamClock/borders.cpp
@@ -29,19 +29,7 @@
 
 #include "HamClock.h"
 
-/* return c blended most of the way toward white, for a brighter day-side rendition of whatever
- * base border/state color the user picked in Setup's color editor.
- */
-static uint16_t brightenForDay (uint16_t c)
-{
-    uint8_t r = RGB565_R(c);
-    uint8_t g = RGB565_G(c);
-    uint8_t b = RGB565_B(c);
-    r += (255-r)*3/4;
-    g += (255-g)*3/4;
-    b += (255-b)*3/4;
-    return (RGB565(r,g,b));
-}
+#define STATES_MIN_SPAN_PX  16           // LOD cutoff for states/provinces -- see drawBorderSet()
 
 /* return the night-side (base) line thickness, in pixels, for the given color selection.
  * N.B. deliberately reads the color editor's thin/thick tick box directly rather than going through
@@ -270,12 +258,24 @@ static bool borderPtIsDay (float lat, float lng)
     return (cos_t > 0);
 }
 
-/* draw bs's overlay from its cached projected points, using day_color/day_thick over the sunlit
- * half of the map and night_color/night_thick over the night (or twilight) half, so the overlay
- * stays visible against the brighter daytime map imagery.
+/* draw bs's overlay from its cached projected points. Line color is always the actual color the
+ * user picked in Setup's color editor (day and night use the same color now -- no brightening),
+ * but thickness still steps up by one pixel on the sunlit half so the overlay stays visible
+ * against the brighter daytime map imagery.
+ *
+ * min_span_px, if nonzero, is a level-of-detail cutoff in ordinary screen pixels: any ring whose
+ * on-screen bounding box is smaller than this in both dimensions is skipped outright rather than
+ * drawn as an unreadable speck. (bs->scr[] itself is in HamClock's raw/supersampled pixel space,
+ * tft.SCALESZ times bigger than the screen -- converted internally so callers can just think in
+ * normal pixels.) Judged per-ring from the already-projected screen points, so it naturally scales with
+ * zoom -- a small country/province gets skipped over a wide view but appears once zoomed in
+ * enough to actually read. Mainly needed for states/provinces: many countries define dozens of
+ * small first-level divisions that otherwise turn into unreadable clutter (e.g. central Africa).
+ * National borders don't pass this (see drawCountryBorders()) since even small countries are
+ * still meaningful at any zoom level borders are shown at.
  */
 static void drawBorderSet (BorderSet *bs, uint16_t day_color, uint16_t night_color,
-                            uint16_t day_thick, uint16_t night_thick)
+                            uint16_t day_thick, uint16_t night_thick, uint16_t min_span_px = 0)
 {
     if (!bs->loaded)
         return;
@@ -283,6 +283,26 @@ static void drawBorderSet (BorderSet *bs, uint16_t day_color, uint16_t night_col
     uint32_t pi = 0;
     for (uint16_t r = 0; r < bs->n_rings; r++) {
         uint16_t npts = bs->ring_len[r];
+
+        if (min_span_px > 0) {
+            uint32_t min_span_raw = (uint32_t)min_span_px * tft.SCALESZ;   // scr[] is raw pixel space
+            int32_t xlo = INT32_MAX, xhi = INT32_MIN, ylo = INT32_MAX, yhi = INT32_MIN;
+            for (uint16_t p = 0; p < npts; p++) {
+                const SCoord &s = bs->scr[pi+p];
+                if (s.x == 0)                        // off-map sentinel
+                    continue;
+                if (s.x < xlo) xlo = s.x;
+                if (s.x > xhi) xhi = s.x;
+                if (s.y < ylo) ylo = s.y;
+                if (s.y > yhi) yhi = s.y;
+            }
+            bool degenerate = (xlo > xhi);            // no valid on-screen points at all
+            if (degenerate || ((uint32_t)(xhi-xlo) < min_span_raw && (uint32_t)(yhi-ylo) < min_span_raw)) {
+                pi += npts;
+                continue;
+            }
+        }
+
         for (uint16_t p = 0; p < npts; p++) {
             uint32_t i0 = pi + p;
             uint32_t i1 = pi + (p+1) % npts;             // wrap last vertex back to first, closed ring
@@ -339,18 +359,16 @@ void drawCountryBorders(void)
     if (!borders_on)
         return;
 
-    uint16_t bclr_night = getMapColor (BORDERS_CSPR);
-    uint16_t bclr_day = brightenForDay (bclr_night);
+    uint16_t bclr = getMapColor (BORDERS_CSPR);
     int bthick_night = borderBaseThick (BORDERS_CSPR);
 
-    drawBorderSet (&bset_borders, bclr_day, bclr_night, bthick_night+1, bthick_night);
+    drawBorderSet (&bset_borders, bclr, bclr, bthick_night+1, bthick_night);
 
     if (pan_zoom.zoom == MAX_ZOOM) {
-        uint16_t sclr_night = getMapColor (STATES_CSPR);
-        uint16_t sclr_day = brightenForDay (sclr_night);
+        uint16_t sclr = getMapColor (STATES_CSPR);
         int sthick_night = borderBaseThick (STATES_CSPR);
 
-        drawBorderSet (&bset_states, sclr_day, sclr_night, sthick_night+1, sthick_night);
+        drawBorderSet (&bset_states, sclr, sclr, sthick_night+1, sthick_night, STATES_MIN_SPAN_PX);
     }
 }
 

--- a/ESPHamClock/earthmap.cpp
+++ b/ESPHamClock/earthmap.cpp
@@ -945,8 +945,9 @@ static void drawBordersButton()
     borders_btn_b.y = view_btn_b.y;             // track the View button's row, incl grid-label offset
 
     if (!bordersBadgeVisible()) {
-        // wrong core map or an azimuthal projection -- just be sure it's left blank
-        tft.fillRect (borders_btn_b.x, borders_btn_b.y, borders_btn_b.w-1, borders_btn_b.h-1, RA8875_BLACK);
+        // wrong core map or an azimuthal projection -- leave it alone. The map sweep already
+        // painted real map pixels through this area, so don't stamp a black box over them --
+        // that just leaves a stray black bar sitting on top of the map.
         return;
     }
 
@@ -1927,6 +1928,15 @@ bool segmentSpanOk (const SCoord &s0, const SCoord &s1, uint16_t border)
         return (false);         // over the view button
     if (!overMap(s0) || !overMap(s1))
         return (false);         // off the map entirely
+    // Reject anything whose drawn extent (border) would poke past map_b's own rectangle --
+    // e.g. a fat dot or arrowhead whose *center* point is on-map but whose edge isn't, which
+    // otherwise bleeds into whatever sits just outside the map (like the DE/DX info panes).
+    if (s0.x < map_b.x+border || s0.x > map_b.x+map_b.w-border
+                        || s0.y < map_b.y+border || s0.y > map_b.y+map_b.h-border)
+        return (false);
+    if (s1.x < map_b.x+border || s1.x > map_b.x+map_b.w-border
+                        || s1.y < map_b.y+border || s1.y > map_b.y+map_b.h-border)
+        return (false);
     return (true);              // ok!
 }
 
@@ -1938,6 +1948,7 @@ bool segmentSpanOk (const SCoord &s0, const SCoord &s1, uint16_t border)
 bool segmentSpanOkRaw (const SCoord &s0, const SCoord &s1, uint16_t border)
 {
     uint16_t map_x = tft.SCALESZ*map_b.x;
+    uint16_t map_y = tft.SCALESZ*map_b.y;
     uint16_t map_w = tft.SCALESZ*map_b.w;
     uint16_t map_h = tft.SCALESZ*map_b.h;
 
@@ -1954,5 +1965,14 @@ bool segmentSpanOkRaw (const SCoord &s0, const SCoord &s1, uint16_t border)
         return (false);         // over the view button
     if (!overMap(raw2appSCoord(s0)) || !overMap(raw2appSCoord(s1)))
         return (false);         // off the map entirely
+    // same edge-extent guard as segmentSpanOk() above, just in raw (scaled) pixel space --
+    // keeps fat dots/arrowheads on satellite/DX paths from bleeding past map_b into whatever
+    // sits just outside it (DE/DX info panes, view button, etc).
+    if (s0.x < map_x+border || s0.x > map_x+map_w-border
+                        || s0.y < map_y+border || s0.y > map_y+map_h-border)
+        return (false);
+    if (s1.x < map_x+border || s1.x > map_x+map_w-border
+                        || s1.y < map_y+border || s1.y > map_y+map_h-border)
+        return (false);
     return (true);              // ok!
 }

--- a/ESPHamClock/setup.cpp
+++ b/ESPHamClock/setup.cpp
@@ -137,6 +137,9 @@ static char i2c_fn[NV_I2CFN_LEN];
 #define CSEL_EDX        90                      // editing tick box dx from first tick box x
 #define CSEL_TDX        30                      // thickness tick box dx from first tick box x
 #define CSEL_GAMMA      1.5F                    // swatch background gray scale gamma correction
+#define CSEL_NSDY       6                       // extra downward nudge for the National/States rows
+                                                 //   and their Thin/Edit sub-header so the header
+                                                 //   text isn't crowded against the blue RGB slider
 
 // color table save/load layout
 #define CTSL_H          (PR_A+PR_D)             // color table save/load height
@@ -1208,19 +1211,19 @@ static ColSelPrompt csel_pr[N_CSPR] = {
     // rows 1-3 in column 2 are occupied by the RGB editing sliders/title -- country/state border
     // colors live in rows 4-5, the first genuinely free rows above the column-2 header (row 6)
     // and the first real column-2 entry (row 7).
-    {{CSEL_COL2X+CSEL_PDX, R2Y(4), CSEL_PW, PR_H},
-            {CSEL_COL2X+CSEL_TDX, R2Y(4)+CSEL_TBDY, CSEL_TBSZ, CSEL_TBSZ},
-            {CSEL_COL2X+CSEL_EDX, R2Y(4)+CSEL_TBDY, CSEL_TBSZ, CSEL_TBSZ},
+    {{CSEL_COL2X+CSEL_PDX, R2Y(4)+CSEL_NSDY, CSEL_PW, PR_H},
+            {CSEL_COL2X+CSEL_TDX, R2Y(4)+CSEL_NSDY+CSEL_TBDY, CSEL_TBSZ, CSEL_TBSZ},
+            {CSEL_COL2X+CSEL_EDX, R2Y(4)+CSEL_NSDY+CSEL_TBDY, CSEL_TBSZ, CSEL_TBSZ},
             {0, 0, 0, 0},                                                       // always on -- see on-map Borders badge
-            {CSEL_COL2X+CSEL_DDX2, R2Y(4)+CSEL_DDY, CSEL_DW, CSEL_DH},
+            {CSEL_COL2X+CSEL_DDX2, R2Y(4)+CSEL_NSDY+CSEL_DDY, CSEL_DW, CSEL_DH},
             false, true, true, RGB565(200,200,200), NV_BORDERCOLOR, "National",
             {0, 0, 0, 0}, false, 0, 0, 0},                                      // never dashed
 
-    {{CSEL_COL2X+CSEL_PDX, R2Y(5), CSEL_PW, PR_H},
-            {CSEL_COL2X+CSEL_TDX, R2Y(5)+CSEL_TBDY, CSEL_TBSZ, CSEL_TBSZ},
-            {CSEL_COL2X+CSEL_EDX, R2Y(5)+CSEL_TBDY, CSEL_TBSZ, CSEL_TBSZ},
+    {{CSEL_COL2X+CSEL_PDX, R2Y(5)+CSEL_NSDY, CSEL_PW, PR_H},
+            {CSEL_COL2X+CSEL_TDX, R2Y(5)+CSEL_NSDY+CSEL_TBDY, CSEL_TBSZ, CSEL_TBSZ},
+            {CSEL_COL2X+CSEL_EDX, R2Y(5)+CSEL_NSDY+CSEL_TBDY, CSEL_TBSZ, CSEL_TBSZ},
             {0, 0, 0, 0},                                                       // always on -- shown automatically at max zoom
-            {CSEL_COL2X+CSEL_DDX2, R2Y(5)+CSEL_DDY, CSEL_DW, CSEL_DH},
+            {CSEL_COL2X+CSEL_DDX2, R2Y(5)+CSEL_NSDY+CSEL_DDY, CSEL_DW, CSEL_DH},
             false, true, true, RGB565(150,150,150), NV_STATECOLOR, "States",
             {0, 0, 0, 0}, false, 0, 0, 0},                                      // never dashed
 };
@@ -2943,8 +2946,8 @@ static void drawCSelInitGUI()
 
     // also label the National/States rows just above them, in the narrow gap between the RGB
     // sliders and row 4 -- only Thin and Edit apply to these two rows, so only label those
-    tft.setCursor (CSEL_COL2X+CSEL_TDX,  CSEL_SCY+3*CSEL_SCH+2*CSEL_SCYG+2); tft.print ("Thin");
-    tft.setCursor (CSEL_COL2X+CSEL_EDX,  CSEL_SCY+3*CSEL_SCH+2*CSEL_SCYG+2); tft.print ("Edit");
+    tft.setCursor (CSEL_COL2X+CSEL_TDX,  CSEL_SCY+3*CSEL_SCH+2*CSEL_SCYG+2+CSEL_NSDY); tft.print ("Thin");
+    tft.setCursor (CSEL_COL2X+CSEL_EDX,  CSEL_SCY+3*CSEL_SCH+2*CSEL_SCYG+2+CSEL_NSDY); tft.print ("Edit");
 
     // N.B. must restore default font after using smaller font
     selectFontStyle (LIGHT_FONT, SMALL_FONT);


### PR DESCRIPTION
…rlay clipping and clutter

- setup.cpp: nudge National/States rows and their Thin/Edit sub-header down (CSEL_NSDY) so the header text isn't crowded against the blue RGB slider

- earthmap.cpp: stop painting a black box over the Borders On/Off badge area when it's not applicable (e.g. non-Clouds/Terrain map styles) -- the map sweep already draws real pixels there, so just leave it alone instead of stamping over them

- earthmap.cpp: segmentSpanOk/segmentSpanOkRaw now reject any segment whose fat-line/dot/arrow extent (border) would poke past map_b's rectangle, not just its center point -- fixes satellite path markers bleeding into the DE/DX info panes

- borders.cpp: drop the day-side color brightening on national/state border lines -- always draw the actual configured color, day and night

- borders.cpp: add an optional level-of-detail cutoff to drawBorderSet() (STATES_MIN_SPAN_PX) that skips states/provinces too small on screen to read, so dense regions (e.g. central Africa) don't turn into unreadable clutter at max zoom