### PR TITLE
Add keyboard nav (arrows + space) to accordion pane picker

### DIFF
--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -812,6 +812,7 @@ typedef struct {
     float kHz;                          // freq
     float snr;                          // only used by pskreporter.cpp
     time_t spotted;                     // UTC when spotted
+    char iota[8];                       // IOTA group ref found in comment, eg "EU-005"; else empty
 } DXSpot;
 
 
@@ -1396,7 +1397,8 @@ extern bool getClosestDXCluster (LatLong &ll, DXSpot *sp, LatLong *llp);
 extern bool getDXCPaneSpot (const SCoord &ms, DXSpot *dxs, LatLong *ll);
 extern bool connectDXCluster (void);
 extern const DXSpot *findDXCCall (const char *call);
-extern bool injectDXClusterSpot (const char *tx_call, const char *rx_call, const char *kHz, Message &ynot);
+extern bool injectDXClusterSpot (const char *tx_call, const char *rx_call, const char *kHz,
+const char *comment, Message &ynot);
 
 
 

--- a/ESPHamClock/Makefile
+++ b/ESPHamClock/Makefile
@@ -130,6 +130,7 @@ OBJS = \
 	launches.o \
 	lightning.o \
 	infobox.o \
+	iota.o \
 	liveweb.o \
 	liveweb-html.o \
 	magdecl.o \

--- a/ESPHamClock/dxcluster.cpp
+++ b/ESPHamClock/dxcluster.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "HamClock.h"
+#include "iota.h"
 
 
 // layout 
@@ -1007,6 +1008,10 @@ bool updateDXCluster (const SBox &box, bool fresh)
         showDXCHost (box, RA8875_GREEN);
     }
 
+    // refresh the IOTA ref->name lookup too -- cheap no-op most calls since
+    // openCachedFile() enforces its own IOTA_CACHE_INTERVAL internally
+    retrieveIOTACache();
+
     if (dxc_ss.atNewest()) {
         // rebuild displayed spots list when master list changes or oldest spot ages out
         bool map_spots_changed = dxc_spots_changed;
@@ -1134,8 +1139,21 @@ bool checkDXClusterTouch (const SCoord &s, const SBox &box)
     int vis_row = (s.y - (box.y + LISTING_Y0)) / LISTING_DY;
     int spot_row;
     if (dxc_ss.findDataIndex (vis_row, spot_row)
-                        && dxwl_spots[spot_row].tx_call[0] != '\0' && isDXClusterConnected())
-        engageDXCRow (dxwl_spots[spot_row]);
+                        && dxwl_spots[spot_row].tx_call[0] != '\0' && isDXClusterConnected()) {
+        DXSpot &sp = dxwl_spots[spot_row];
+        if (sp.iota[0]) {
+            // show the resolved name (or just the bare ref if cache hasn't loaded
+            // it yet) instead of the normal engage action -- tap again to engage
+            const char *name = lookupIOTAName (sp.iota);
+            char tip[64];
+            if (name)
+                snprintf (tip, sizeof(tip), "IOTA %s: %s", sp.iota, name);
+            else
+                snprintf (tip, sizeof(tip), "IOTA %s", sp.iota);
+            tooltip (s, tip);
+        } else
+            engageDXCRow (sp);
+    }
 
     // ours 
     return (true);
@@ -1321,14 +1339,20 @@ const DXSpot *findDXCCall (const char *call)
 }
 
 /* inject a fake DXSpot, typically from RESTful command.
+ * comment is optional (may be NULL) -- only used to test IOTA reference matching, same as a real
+ * cluster spot's comment text would be.
  * return true else short reason why not.
  */
-bool injectDXClusterSpot (const char *tx_call, const char *rx_call, const char *kHz, Message &ynot)
+bool injectDXClusterSpot (const char *tx_call, const char *rx_call, const char *kHz,
+const char *comment, Message &ynot)
 {
     DXSpot fake = {};
 
     quietStrncpy (fake.tx_call, tx_call, sizeof(fake.tx_call));
     quietStrncpy (fake.rx_call, rx_call, sizeof(fake.rx_call));
+
+    if (comment)
+        findIOTARef (comment, fake.iota, sizeof(fake.iota));
 
     char *endptr;
     fake.kHz = strtod (kHz, &endptr);

--- a/ESPHamClock/infobox.cpp
+++ b/ESPHamClock/infobox.cpp
@@ -2,6 +2,7 @@
  */
 
 #include "HamClock.h"
+#include "iota.h"
 
 #define IB_LINEDY       9                       // line height, pixels
 #define IB_NLINES       12                      // allow this many lines in box
@@ -23,6 +24,26 @@ static void drawIB_Age (time_t t, uint16_t tx, int dy, uint16_t &ty)
     char str[10];
     tft.setCursor (tx, ty += dy);
     tft.printf ("Age  %s", formatAge (age_s, str, sizeof(str), 4));
+}
+
+/* drawMouseLoc() helper to show a spot's IOTA reference, if it has one.
+ * update ty by dy for each row used -- draws (and costs) nothing if iota_ref is empty.
+ */
+static void drawIB_IOTA (const char *iota_ref, uint16_t tx, int dy, uint16_t &ty)
+{
+    if (!iota_ref || !iota_ref[0])
+        return;
+
+    // "IOTA" tag, centered like the "NCS" tag under a Net Control callsign
+    static const char iota_tag[] = "IOTA";
+    uint16_t tw = getTextWidth (iota_tag);
+    tft.setCursor (tx + (view_btn_b.w-tw)/2, ty += dy);
+    tft.print (iota_tag);
+
+    // the reference itself, eg "EU-005", centered the same way
+    tw = getTextWidth (iota_ref);
+    tft.setCursor (tx + (view_btn_b.w-tw)/2, ty += dy);
+    tft.print (iota_ref);
 }
 
 /* drawMouseLoc() helper to show DE distance and bearing to given location.
@@ -401,6 +422,9 @@ static void drawIB_DX (const SBox &minfo_b, const DXSpot &dx_s, const LatLong &d
 
     // show freq
     drawIB_Freq (dx_s.kHz*1000, tx+IB_INDENT, IB_LINEDY, ty);
+
+    // show IOTA reference, if this spot has one -- costs no space if not
+    drawIB_IOTA (dx_s.iota, tx+IB_INDENT, IB_LINEDY, ty);
 
     // show spot age
     drawIB_Age (dx_s.spotted, tx+IB_INDENT, IB_LINEDY, ty);

--- a/ESPHamClock/iota.cpp
+++ b/ESPHamClock/iota.cpp
@@ -1,0 +1,102 @@
+/* iota.cpp -- IOTA group reference -> name lookup.
+ *
+ * Fed by fetchIOTA.py running on the backend server, which turns
+ * iota-world.org's groups.json into a small REF,Name cache at /ONTA/iota.txt.
+ * That file is a *reference database*, not a live spot feed -- there is no
+ * "who's activating what right now" feed from iota-world.org -- so unlike
+ * onta.txt this is used only to enrich ordinary DX Cluster spots whose
+ * comment happens to mention an IOTA group, not to drive its own pane.
+ */
+
+#include "HamClock.h"
+
+#include <unordered_map>
+#include <string>
+#include <cctype>
+#include <cstring>
+#include <sys/stat.h>
+
+#include "iota.h"
+
+static const char iota_page[] = "/ONTA/iota.txt";      // matches fetchIOTA.py deployment
+static const char iota_file[] = "iota.txt";             // local cache file
+#define IOTA_CACHE_INTERVAL   (24*3600)                  // group defs barely ever change
+
+static std::unordered_map<std::string, std::string> iota_names;
+static time_t iota_cache_mtime;                          // mtime of local file when last parsed
+
+/* (re)load the REF -> Name cache if due. safe -- indeed intended -- to call on every DX Cluster
+ * update cycle (every few seconds): openCachedFile() itself throttles the actual network check to
+ * IOTA_CACHE_INTERVAL, and even the local reopen+stat it does every call is cheap. What must NOT
+ * happen every call is rebuilding iota_names from scratch -- with ~1200 groups that's real CPU and
+ * heap churn on an ESP32 if done every second forever -- so skip the rebuild unless the file's mtime
+ * shows it's genuinely different from what we last parsed.
+ */
+void retrieveIOTACache (void)
+{
+    FILE *fp = openCachedFile (iota_file, iota_page, IOTA_CACHE_INTERVAL, 0);
+    if (!fp)
+        return;
+
+    // has the file actually changed since we last parsed it?
+    struct stat sbuf;
+    if (fstat (fileno(fp), &sbuf) == 0 && sbuf.st_mtime == iota_cache_mtime) {
+        fclose (fp);
+        return;                                           // unchanged -- nothing to do
+    }
+
+    iota_names.clear();
+
+    char line[80];
+    while (fgets (line, sizeof(line), fp)) {
+        chompString (line);
+        if (line[0] == '#' || line[0] == '\0')
+            continue;
+        char *comma = strchr (line, ',');
+        if (!comma)
+            continue;
+        *comma = '\0';
+        iota_names[line] = comma + 1;                   // ref -> rest of line is name
+    }
+
+    iota_cache_mtime = sbuf.st_mtime;
+    fclose (fp);
+
+    Serial.printf ("IOTA: read %d group names\n", (int)iota_names.size());
+}
+
+/* an IOTA group reference looks like AA-123: 2 letters, dash, 3 digits.
+ * scan comment for the first match.
+ */
+bool findIOTARef (const char *comment, char *out, size_t out_len)
+{
+    if (!comment || out_len < 8)
+        return (false);
+
+    size_t len = strlen (comment);
+    for (size_t i = 0; i + 6 <= len; i++) {
+        const char *p = comment + i;
+        if (isalpha ((unsigned char)p[0]) && isalpha ((unsigned char)p[1]) && p[2] == '-'
+                    && isdigit ((unsigned char)p[3]) && isdigit ((unsigned char)p[4])
+                    && isdigit ((unsigned char)p[5])
+                    // must not be glued to more alnum chars on either side, else
+                    // eg the middle of a longer token could false-match
+                    && (i == 0 || !isalnum ((unsigned char)comment[i-1]))
+                    && (i+6 == len || !isalnum ((unsigned char)p[6]))) {
+            out[0] = toupper ((unsigned char)p[0]);
+            out[1] = toupper ((unsigned char)p[1]);
+            memcpy (out+2, p+2, 4);
+            out[6] = '\0';
+            return (true);
+        }
+    }
+    return (false);
+}
+
+const char *lookupIOTAName (const char *ref)
+{
+    if (!ref || !ref[0])
+        return (NULL);
+    auto it = iota_names.find (ref);
+    return (it == iota_names.end() ? NULL : it->second.c_str());
+}

--- a/ESPHamClock/iota.h
+++ b/ESPHamClock/iota.h
@@ -1,0 +1,22 @@
+/* iota.h -- lookup for IOTA group reference -> name, resolved from DX Cluster
+ * spot comments. Cache built server-side by fetchIOTA.py, same pattern as
+ * ontheair.cpp's onta_parks.txt.
+ */
+
+#ifndef _IOTA_H
+#define _IOTA_H
+
+// call periodically (eg alongside retrieveONTAParks()); cheap no-op most of
+// the time since openCachedFile() enforces its own refresh interval.
+extern void retrieveIOTACache (void);
+
+// look for an IOTA-shaped reference (eg "EU-005") anywhere in comment; if
+// found copy it upper-cased into out (>= 8 bytes) and return true.
+extern bool findIOTARef (const char *comment, char *out, size_t out_len);
+
+// look up the group name for a reference already extracted with findIOTARef().
+// returns NULL if not (yet) in the cache -- caller should still show the raw
+// reference in that case, same fallback spirit as ontaStateOrCountry().
+extern const char *lookupIOTAName (const char *ref);
+
+#endif // _IOTA_H

--- a/ESPHamClock/parsespot.cpp
+++ b/ESPHamClock/parsespot.cpp
@@ -3,6 +3,7 @@
 
 
 #include "HamClock.h"
+#include "iota.h"
 
 
 
@@ -47,6 +48,10 @@ bool crackClusterSpot (char line[], DXSpot &spot)
 
     // spot does not include mode so try to set based on freq
     quietStrncpy (spot.mode, findHamMode (spot.kHz), sizeof(spot.mode));
+
+    // comment is whatever text sits between the callsign and the time field at
+    // line[70]; scan it for a recognizable IOTA group reference
+    findIOTARef (line, spot.iota, sizeof(spot.iota));
 
     // accommodate future from roundoff
     if (spot.spotted > now) {

--- a/ESPHamClock/plotmgmnt.cpp
+++ b/ESPHamClock/plotmgmnt.cpp
@@ -443,6 +443,50 @@ static int accordionOrderKey (const char *label)
     return (-1);        // no override -- sort below keeps it in its natural position
 }
 
+/* move focus_row to whichever of the n_row_boxes entries is closest in the given arrow
+ * direction, same nearest-neighbor-in-that-direction technique menu.cpp's kbNavigation() uses
+ * for every other menu -- just scoped to this frame's row set instead of a MenuInfo's full
+ * item list, since row_boxes here is already exactly "this frame's active, navigable items"
+ * with no MENU_ACTIVE-style filtering needed. No-op for any other key. If focus_row is
+ * currently unfocused (-1) or points past the end of a shrunk row set, any arrow key just
+ * focuses the first row instead of searching from a stale/nonexistent position.
+ */
+static void accordionKbMove (const SBox *row_boxes, int n_row_boxes, int &focus_row, char kb_char)
+{
+    if (n_row_boxes == 0)
+        return;
+
+    if (focus_row < 0 || focus_row >= n_row_boxes) {
+        focus_row = 0;
+        return;
+    }
+
+    const SBox &pm = row_boxes[focus_row];
+    int mind = 100000;
+    int candidate = -1;
+
+    for (int i = 0; i < n_row_boxes; i++) {
+        if (i == focus_row)
+            continue;
+        const SBox &pi = row_boxes[i];
+        int d = abs((int)pi.x - (int)pm.x) + abs((int)pi.y - (int)pm.y);
+        bool dir_ok = false;
+        switch (kb_char) {
+        case CHAR_LEFT:  dir_ok = pi.x < pm.x; break;
+        case CHAR_RIGHT: dir_ok = pi.x > pm.x; break;
+        case CHAR_UP:    dir_ok = pi.y < pm.y; break;
+        case CHAR_DOWN:  dir_ok = pi.y > pm.y; break;
+        default: return;                       // not an arrow key -- leave focus alone
+        }
+        if (dir_ok && d < mind) {
+            candidate = i;
+            mind = d;
+        }
+    }
+    if (candidate >= 0)
+        focus_row = candidate;
+}
+
 static bool askPaneCategoryAccordion (PlotPane pp, SBox box, MenuItem *mitems, int n_mitems)
 {
     // one header per non-empty category, in display order; cat_total[] doesn't change once
@@ -484,6 +528,9 @@ static bool askPaneCategoryAccordion (PlotPane pp, SBox box, MenuItem *mitems, i
 
     int expanded_cat = -1;             // -1 == every category collapsed
     int last_h = 0;                    // box height actually drawn last frame, for erase-sizing
+    int focus_row = -1;                // -1 == no keyboard focus yet -- matches the rest of the
+                                        // app's convention of not showing a focus highlight
+                                        // until the person actually presses an arrow key
     bool ok = false;
 
     menu_open_for_pane = pp;            // let showRotatingBorder()/accordionServiceOtherPanes()
@@ -599,7 +646,7 @@ static bool askPaneCategoryAccordion (PlotPane pp, SBox box, MenuItem *mitems, i
 
                 SBox hb = {(uint16_t)(vis_box.x + ACC_LM), (uint16_t)(vis_box.y + ACC_TBM + row*ACC_RH),
                            (uint16_t)(vis_box.w - ACC_LM - ACC_RM), ACC_RH};
-                menuDrawItem (hmi, hb, true, false);
+                menuDrawItem (hmi, hb, true, n_row_boxes == focus_row);
                 row_boxes[n_row_boxes] = hb;
                 row_is_header[n_row_boxes] = true;
                 row_data[n_row_boxes] = c;
@@ -620,7 +667,7 @@ static bool askPaneCategoryAccordion (PlotPane pp, SBox box, MenuItem *mitems, i
                         SBox cb = {(uint16_t)(vis_box.x + ACC_LM + col*col_w),
                                    (uint16_t)(vis_box.y + ACC_TBM + (row+row_in_col)*ACC_RH),
                                    (uint16_t)col_w, ACC_RH};
-                        menuDrawItem (cmi, cb, true, false);
+                        menuDrawItem (cmi, cb, true, n_row_boxes == focus_row);
                         row_boxes[n_row_boxes] = cb;
                         row_is_header[n_row_boxes] = false;
                         row_data[n_row_boxes] = exp_children[j];
@@ -687,8 +734,31 @@ static bool askPaneCategoryAccordion (PlotPane pp, SBox box, MenuItem *mitems, i
             ok = false;
             break;
         }
+        if (ui.kb_char == CHAR_LEFT || ui.kb_char == CHAR_RIGHT
+                        || ui.kb_char == CHAR_UP || ui.kb_char == CHAR_DOWN) {
+            accordionKbMove (row_boxes, n_row_boxes, focus_row, ui.kb_char);
+            continue;
+        }
+        if (ui.kb_char == CHAR_CR || ui.kb_char == CHAR_NL) {
+            if (enable_ok) {
+                ok = true;
+                break;
+            }
+            menuMsg (cur_box, RA8875_RED, "Select an item");
+            continue;
+        }
+        if (ui.kb_char == CHAR_SPACE && focus_row >= 0 && focus_row < n_row_boxes) {
+            if (row_is_header[focus_row]) {
+                int tapped_cat = row_data[focus_row];
+                expanded_cat = (tapped_cat == expanded_cat) ? -1 : tapped_cat;
+            } else {
+                int mi_idx = row_data[focus_row];
+                mitems[mi_idx].set = !mitems[mi_idx].set;
+            }
+            continue;
+        }
         if (ui.kb_char != CHAR_NONE)
-            continue;                          // ignore other keys, this picker is tap-only
+            continue;                          // ignore any other key
 
         if (inBox (ui.tap, ok_b)) {
             if (enable_ok) {

--- a/ESPHamClock/spots.cpp
+++ b/ESPHamClock/spots.cpp
@@ -3,6 +3,9 @@
 
 #include "HamClock.h"
 
+#define IOTA_MARK_COLOR RGB565(150,250,255)     // matches ONTA_COLOR; box behind the "I" flags an IOTA ref
+#define IOTA_MARK_W     9                        // pixels reserved for the marker column, incl gap
+
 
 /* find list element, subject to possible filtering, that is closest to ll on the given end(s).
  * return whether found one within MAX_CSR_DIST.
@@ -196,11 +199,26 @@ void drawSpotOnList (const SBox &box, const DXSpot &spot, int row, uint16_t bg_c
     tft.setCursor (x, y);
     tft.print (line);
 
-    // add call
-    const int max_call = BOX_IS_PANE_0(box) ? MAX_SPOTCALL_LEN-3 : MAX_SPOTCALL_LEN-1;
+    // add call -- 2 chars narrower than before to make room for a fixed-width IOTA marker
+    // column, so the age field always starts in the same place whether or not a row has one
+    const int max_call = BOX_IS_PANE_0(box) ? MAX_SPOTCALL_LEN-5 : MAX_SPOTCALL_LEN-3;
     tft.setTextColor(RA8875_WHITE);
     snprintf (line, sizeof(line), " %-*.*s ", max_call, max_call, spot.tx_call);
     tft.print (line);
+
+    // reserve a small fixed-width column for an IOTA marker -- reserved on every row, drawn only
+    // when this spot's comment carried a recognized IOTA reference, so the age field lines up in
+    // the same column either way instead of drifting into it (as a plain floating dot used to).
+    // full name doesn't fit here -- tap the row (see checkDXClusterTouch) to see it in a tooltip.
+    uint16_t call_end_x = tft.getCursorX();
+    if (spot.iota[0]) {
+        tft.fillRect (call_end_x, y-LISTING_OS, IOTA_MARK_W, h, IOTA_MARK_COLOR);
+        tft.setTextColor (RA8875_BLACK);
+        tft.setCursor (call_end_x + 2, y);
+        tft.print ('I');
+        tft.setTextColor (RA8875_WHITE);
+    }
+    tft.setCursor (call_end_x + IOTA_MARK_W, y);
 
     // and finally age, width depending on pane
     time_t age = myNow() - spot.spotted;

--- a/ESPHamClock/webserver.cpp
+++ b/ESPHamClock/webserver.cpp
@@ -2041,20 +2041,22 @@ static bool setWiFiSpot (WiFiClient &client, char line[], size_t line_len)
     wa.name[wa.nargs++] = "tx_call";
     wa.name[wa.nargs++] = "rx_call";
     wa.name[wa.nargs++] = "kHz";
+    wa.name[wa.nargs++] = "comment";            // optional; only used to test IOTA ref matching
 
     // parse
     if (!parseWebCommand (wa, line, line_len))
         return (false);
 
-    // all required
+    // first 3 required, comment is optional
     if (!wa.found[0] || !wa.found[1] || !wa.found[2]) {
-        snprintf (line, line_len, "%s", "tx_call=x&rx_call=x&kHz=x");
+        snprintf (line, line_len, "%s", "tx_call=x&rx_call=x&kHz=x[&comment=x]");
         return (false);
     }
 
     // inject
     Message ynot;
-    if (!injectDXClusterSpot (wa.value[0], wa.value[1], wa.value[2], ynot)) {
+    if (!injectDXClusterSpot (wa.value[0], wa.value[1], wa.value[2],
+                                wa.found[3] ? wa.value[3] : NULL, ynot)) {
         quietStrncpy (line, ynot.get(), line_len);
         return (false);
     }
@@ -4772,7 +4774,7 @@ static const CmdTble command_table[] = {
 
     // the following entries are never shown with --help -- update N_UNDOC_CMD if change
     { "set_demo?",          setWiFiDemo,           "on|off|n=N" },
-    { "set_spot?",          setWiFiSpot,           "tx_call=x&rx_call=x&kHz=x" },
+    { "set_spot?",          setWiFiSpot,           "tx_call=x&rx_call=x&kHz=x[&comment=x]" },
 };
 
 #define N_CMDTABLE      NARRAY(command_table)           // real n entries in command table


### PR DESCRIPTION
- plotmgmnt.cpp: accordionKbMove() moves focus among the current frame's visible rows (headers + expanded children) using the same nearest-neighbor-in-direction logic as menu.cpp's kbNavigation()
- Space activates the focused row (toggle item, or expand/collapse category); Enter triggers Ok (same "Select an item" gating as tap); Esc already cancelled
- Focus highlight reuses menuDrawItem()'s existing kb_focus green border; no highlight shown until an arrow key is first pressed
- Note: opening the picker itself via keyboard alone still relies on the existing want_kbcursor/-y cursor-warp feature (touch.cpp), unrelated to this change