### PR TITLE
When UTC button is clicked, it will support switching button to LCL i…

### DIFF
--- a/ESPHamClock/ESPHamClock.cpp
+++ b/ESPHamClock/ESPHamClock.cpp
@@ -2004,7 +2004,7 @@ void drawDEFormatMenu()
 
     // run menu
     SBox ok_b;
-    MenuInfo menu = {menu_b, ok_b, UF_NOCLOCKS, M_CANCELOK, 1, NARRAY(mitems), mitems};
+    MenuInfo menu = {menu_b, ok_b, UF_CLOCKSOK, M_CANCELOK, 1, NARRAY(mitems), mitems};
     if (!runMenu (menu))
         return;
 

--- a/ESPHamClock/clocks.cpp
+++ b/ESPHamClock/clocks.cpp
@@ -85,6 +85,10 @@ static bool time_is_stuck;                      // set if see time not changing 
 // TimeLib's now() stays at real UTC, but user can adjust time offset
 static int utc_offset;                          // nowWO() offset from UTC, secs
 
+// whether the main clocks-pane HMS/date shows DE-local time instead of UTC.
+// N.B. independent of utc_offset -- this only affects what's displayed, not what's stored/synced.
+static bool main_clock_local;
+
 // display 
 #define UTC_W           14                      // UTC button width in upper right corner of clock_b
 #define UTC_H           (HMS_H-1)               // UTC button height in upper right corner of clock_b
@@ -104,10 +108,17 @@ static void drawUTCButton()
     char msg[4];
 
     if (utc_offset == 0 && !time_running_bw && !time_is_stuck) {
-        // at UTC for sure
-        tft.fillRect (clock_b.x+clock_b.w-UTC_W, clock_b.y, UTC_W, UTC_H, HMS_C);
-        tft.setTextColor(RA8875_BLACK);
-        strcpy (msg, "UTC");
+        if (main_clock_local) {
+            // synced, but showing DE-local time instead of UTC
+            tft.fillRect (clock_b.x+clock_b.w-UTC_W, clock_b.y, UTC_W, UTC_H, RA8875_CYAN);
+            tft.setTextColor(RA8875_BLACK);
+            strcpy (msg, "LCL");
+        } else {
+            // at UTC for sure
+            tft.fillRect (clock_b.x+clock_b.w-UTC_W, clock_b.y, UTC_W, UTC_H, HMS_C);
+            tft.setTextColor(RA8875_BLACK);
+            strcpy (msg, "UTC");
+        }
     } else {
         // unknown or time is other than UTC
         bool toggle = (millis()%2000) > 1000;
@@ -946,6 +957,15 @@ void initTime()
         NVWriteInt32 (NV_UTC_OFFSET, utc_offset);
     }
 
+    // get whether main clock shows local time instead of UTC
+    uint8_t mcl;
+    if (NVReadUInt8 (NV_MAINCLOCK_LOCAL, &mcl))
+        main_clock_local = (mcl != 0);
+    else {
+        main_clock_local = false;
+        NVWriteUInt8 (NV_MAINCLOCK_LOCAL, 0);
+    }
+
     // get desired aux time format
     uint8_t at;
     if (!NVReadUInt8(NV_AUX_TIME, &at)) {
@@ -1087,8 +1107,13 @@ void updateClocks(bool all)
     // update status items under callsign (uptime, rotating message, version)
     updateCallsignStatus (all);
 
-    // get user's UTC time now, get out fast if still same second
-    time_t t_wo = nowWO();
+    // get user's UTC time now, get out fast if still same second.
+    // t_utc stays pure UTC (+ any manual utc_offset) for other code below (DE/DX panes) that
+    // applies its own timezone offset; t_wo is what actually gets displayed on the main clock,
+    // shifted to DE-local time here if that's what's selected. nowWO() itself is untouched since
+    // lots of other code (rise/set, satellites, etc) depends on it staying UTC-based.
+    time_t t_utc = nowWO();
+    time_t t_wo = main_clock_local ? t_utc + getTZ (de_tz) : t_utc;
     if ((t_wo%60) == prev_sc && !all)
         return;
 
@@ -1220,7 +1245,7 @@ void updateClocks(bool all)
             break;
         case DETIME_ANALOG:     // fallthru
         case DETIME_ANALOG_DTTM:
-            drawAnalogClock (t_wo + getTZ (de_tz));
+            drawAnalogClock (t_utc + getTZ (de_tz));
             break;
         case DETIME_INFO:
             drawDECalTime(false);
@@ -1228,7 +1253,7 @@ void updateClocks(bool all)
             break;
         case DETIME_DIGITAL_12: // fallthru
         case DETIME_DIGITAL_24: // fallthru
-            drawDigitalClock (t_wo + getTZ (de_tz));
+            drawDigitalClock (t_utc + getTZ (de_tz));
             break;
         default:
             fatalError ("unknown de fmt %d", de_time_fmt);
@@ -1371,11 +1396,15 @@ bool checkClockTouch (SCoord &s)
 
         if (dx >= clock_b.w-UTC_W && dy <= UTC_H) {
 
-            // tapped UTC "button": return to UTC if not already
+            // tapped UTC "button": return to UTC if not already, else toggle main clock
+            // between showing UTC and DE-local time (this tap used to be a no-op in that case)
 
             if (utc_offset != 0 || !clockTimeOk()) {
                 utc_offset = 0;
                 startSyncProvider(true);
+            } else {
+                main_clock_local = !main_clock_local;
+                NVWriteUInt8 (NV_MAINCLOCK_LOCAL, main_clock_local ? 1 : 0);
             }
 
         } else if (dx < safe_dx) {

--- a/ESPHamClock/nvramenum.h
+++ b/ESPHamClock/nvramenum.h
@@ -407,6 +407,9 @@ typedef enum {
     // 261
     NV_STORM_SHOWPATH,               // whether Trop Wx shows storm paths on the map
 
+    // 262
+    NV_MAINCLOCK_LOCAL,               // whether the main clocks-pane HMS/date shows DE-local time instead of UTC
+
 	NV_N
 
 } NV_Name;

--- a/ESPHamClock/nvramsize.h
+++ b/ESPHamClock/nvramsize.h
@@ -410,6 +410,9 @@ static const uint8_t nv_sizes[NV_N] = {
     // 261
     1,                          // NV_STORM_SHOWPATH
 
+    // 262
+    1,                          // NV_MAINCLOCK_LOCAL
+
 };
 
 #endif // _NVRAMSIZE_H

--- a/ESPHamClock/plotmgmnt.cpp
+++ b/ESPHamClock/plotmgmnt.cpp
@@ -376,17 +376,28 @@ static void fitAccordionLayout (int n_cats, int n_children, int budget_h,
 // a tap, so without this, a stray background redraw would sit there until the next tap.
 static std::function<void()> acc_redraw_fn = nullptr;
 
-/* UserInput.fp callback for askPaneCategoryAccordion()'s wait loop: services every OTHER
- * pane's normal rotation/updates (network fetches, redraws, the lot) at a throttled rate while
- * the picker sits waiting for a tap, so opening one pane's picker doesn't stall every other
- * pane's rotation for as long as it's left open. Also services the map overlays (DX Cluster
- * spots and the like) and their underlying data collection, since those are normally driven
- * from the main loop() rather than updateWiFi() and would otherwise sit frozen the whole time
- * a picker is open. Always returns false so waitForUser() just keeps waiting for the next tap
- * -- this is a side-effecting tick, not a wait-ending condition.
+/* UserInput.fp callback for askPaneCategoryAccordion()'s wait loop: keeps the main clock
+ * ticking at its normal cadence (see below) and services every OTHER pane's normal
+ * rotation/updates (network fetches, redraws, the lot) at a throttled rate while the picker
+ * sits waiting for a tap, so opening one pane's picker doesn't stall every other pane's
+ * rotation -- or the clock -- for as long as it's left open. Also services the map overlays
+ * (DX Cluster spots and the like) and their underlying data collection, since those are
+ * normally driven from the main loop() rather than updateWiFi() and would otherwise sit frozen
+ * the whole time a picker is open. Always returns false so waitForUser() just keeps waiting for
+ * the next tap -- this is a side-effecting tick, not a wait-ending condition.
  */
 static bool accordionServiceOtherPanes (void)
 {
+    // tick the clock at its normal fast cadence every time we're called, independent of the
+    // once-a-second throttle below -- updateClocks(false) is cheap (no-ops unless the displayed
+    // second actually changed), so there's no reason it should have to wait behind however long
+    // the heavier pane-refresh work below takes. Without this, the clock only advanced via
+    // waitForUser()'s own post-callback call, which can't run until this function returns -- and
+    // if several other panes happen to be due for a refresh at once, updateWiFi() below services
+    // all of them in one synchronous pass, easily several seconds, freezing the clock for that
+    // whole time.
+    updateClocks (false);
+
     static uint32_t last_ms;
     uint32_t now_ms = millis();
     if (now_ms - last_ms < 1000)               // once a second is plenty; this work can be heavy

--- a/doc/eeprom/hceeprom.csv
+++ b/doc/eeprom/hceeprom.csv
@@ -233,3 +233,4 @@ Addr,Name,Len,Type,Description
 0xCF4,NV_WEFAX_PRODUCT,1,i,index into wefax_products[] of last-selected product
 0xCF6,NV_WEFAX_ENABLE,1,i,whether the WEFAX feature is offered at all (Setup screen)
 0xCF8,NV_STORM_SHOWPATH,1,i,whether Trop Wx shows storm paths on the map
+0xCFA,NV_MAINCLOCK_LOCAL,1,i,whether the main clocks-pane HMS/date shows DE-local time instead of UTC


### PR DESCRIPTION
…n cyan to indicate local time. This is useful when you have the longer data pane open and you aren't showing DE information. Fix existing bug with blocking clock tick when DE Flex Pane/Data Pane is open and fix a regression on clock updates when the pane is selected. This will reduce the perception that the display is locked up.